### PR TITLE
Open OutputStream only when it was not opened

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -177,6 +177,9 @@ public class SftpFileOutput
                         @Override
                         public Void call() throws IOException, RetryGiveupException
                         {
+                            if (!currentFile.isContentOpen()) {
+                                currentFile = newSftpFile(getSftpFileUri(getOutputFilePath()));
+                            }
                             if (currentFile.getContent().isOpen()) {
                                 currentFile.getContent().close();
                             }

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -177,7 +177,9 @@ public class SftpFileOutput
                         @Override
                         public Void call() throws IOException, RetryGiveupException
                         {
-                            currentFileOutputStream = new BufferedOutputStream(currentFile.getContent().getOutputStream());
+                            if (!currentFile.getContent().isOpen()) {
+                                currentFileOutputStream = new BufferedOutputStream(currentFile.getContent().getOutputStream());
+                            }
                             currentFileOutputStream.write(buffer.array(), buffer.offset(), buffer.limit());
                             return null;
                         }

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -177,9 +177,10 @@ public class SftpFileOutput
                         @Override
                         public Void call() throws IOException, RetryGiveupException
                         {
-                            if (!currentFile.getContent().isOpen()) {
-                                currentFileOutputStream = new BufferedOutputStream(currentFile.getContent().getOutputStream());
+                            if (currentFile.getContent().isOpen()) {
+                                currentFile.getContent().close();
                             }
+                            currentFileOutputStream = new BufferedOutputStream(currentFile.getContent().getOutputStream());
                             currentFileOutputStream.write(buffer.array(), buffer.offset(), buffer.limit());
                             return null;
                         }


### PR DESCRIPTION
Followup for #29.

I got following failure at my environment with v0.1.0 that contains #29
I changed implementation to avoid this failure.
```
2017-04-13 05:26:20.257 +0000 [INFO] (0001:transaction): Loaded plugin embulk-input-s3 (0.2.10.1)
2017-04-13 05:26:20.344 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-sftp (0.1.0)
2017-04-13 05:26:21.080 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=32 / tasks=1
2017-04-13 05:26:21.130 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2017-04-13 05:26:22.758 +0000 [INFO] (0014:task-0000): parent directory sftp://username:***@example.com/home/username exists there
2017-04-13 05:26:22.758 +0000 [INFO] (0014:task-0000): new sftp file: sftp://username:***@example.com/home/username/output2.csv
2017-04-13 05:26:23.317 +0000 [WARN] (0014:task-0000): SFTP write request failed. Retrying 1/10 after 0 seconds. Message: Could not write to "sftp://username:***@example.com/home/username/output2.csv" because it is currently in use.
2017-04-13 05:26:23.818 +0000 [WARN] (0014:task-0000): SFTP write request failed. Retrying 2/10 after 1 seconds. Message: Could not write to "sftp://username:***@example.com/home/username/output2.csv" because it is currently in use.
2017-04-13 05:26:24.822 +0000 [WARN] (0014:task-0000): SFTP write request failed. Retrying 3/10 after 2 seconds. Message: Could not write to "sftp://username:***@example.com/home/username/output2.csv" because it is currently in use.
org.apache.commons.vfs2.FileSystemException: Could not write to "sftp://username:***@example.com/home/username/output2.csv" because it is currently in use.
	at org.apache.commons.vfs2.provider.DefaultFileContent.getOutputStream(DefaultFileContent.java:475) ~[na:na]
	at org.apache.commons.vfs2.provider.DefaultFileContent.getOutputStream(DefaultFileContent.java:457) ~[na:na]
	at org.embulk.output.sftp.SftpFileOutput$1.call(SftpFileOutput.java:180) ~[na:na]
	at org.embulk.output.sftp.SftpFileOutput$1.call(SftpFileOutput.java:176) ~[na:na]
	at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:100) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java:77) [embulk-core-0.8.18.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.uploadFile(SftpFileOutput.java:176) [embulk-output-sftp-0.1.0.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.add(SftpFileOutput.java:166) [embulk-output-sftp-0.1.0.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.doFlush(FileOutputOutputStream.java:79) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.flush(FileOutputOutputStream.java:90) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.write(FileOutputOutputStream.java:68) [embulk-core-0.8.18.jar:na]
	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:282) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.write(StreamEncoder.java:125) [na:1.7.0_80]
	at java.io.OutputStreamWriter.write(OutputStreamWriter.java:207) [na:1.7.0_80]
	at java.io.BufferedWriter.flushBuffer(BufferedWriter.java:129) [na:1.7.0_80]
	at java.io.BufferedWriter.write(BufferedWriter.java:230) [na:1.7.0_80]
	at java.io.Writer.write(Writer.java:157) [na:1.7.0_80]
	at java.io.Writer.append(Writer.java:227) [na:1.7.0_80]
	at org.embulk.spi.util.LineEncoder.addText(LineEncoder.java:78) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.addDelimiter(CsvFormatterPlugin.java:197) [embulk-standards-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.longColumn(CsvFormatterPlugin.java:144) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.Column.visit(Column.java:54) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.Schema.visitColumns(Schema.java:81) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1.add(CsvFormatterPlugin.java:131) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.add(FileOutputRunner.java:166) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:244) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.flush(PageBuilder.java:250) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.addRecord(PageBuilder.java:227) [embulk-core-0.8.18.jar:na]
	at org.embulk.parser.msgpack.MsgpackParserPlugin.run(MsgpackParserPlugin.java:280) [embulk-parser-msgpack-0.2.2.jar:na]
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:153) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:67) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:42) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180) [embulk-core-0.8.18.jar:na]
	at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_80]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_80]
2017-04-13 05:26:26.823 +0000 [WARN] (0014:task-0000): SFTP write request failed. Retrying 4/10 after 4 seconds. Message: Could not write to "sftp://username:***@example.com/home/username/output2.csv" because it is currently in use.
```
