### PR TITLE
Improve upload retry logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     provided "org.embulk:embulk-core:0.8.6"
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
     compile "org.apache.commons:commons-vfs2:2.1.1660580.2"
+    compile "commons-io:commons-io:2.5"
     compile "com.jcraft:jsch:0.1.53"
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.6:tests"

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -285,6 +285,9 @@ public class SftpFileOutput
     private FileObject newSftpFile(final URI sftpUri) throws FileSystemException
     {
         FileObject file = manager.resolveFile(sftpUri.toString(), fsOptions);
+        if (file.exists()) {
+            file.delete();
+        }
         if (file.getParent().exists()) {
             logger.info("parent directory {} exists there", file.getParent().getPublicURIString());
         }

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -2,6 +2,7 @@ package org.embulk.output.sftp;
 
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
@@ -15,15 +16,22 @@ import org.embulk.spi.Exec;
 import org.embulk.spi.FileOutput;
 import org.embulk.spi.TransactionalFileOutput;
 import org.embulk.spi.unit.LocalFile;
+import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
+import org.embulk.spi.util.RetryExecutor.Retryable;
 import org.slf4j.Logger;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
 import static org.embulk.output.sftp.SftpFileOutputPlugin.PluginTask;
+import static org.embulk.spi.util.RetryExecutor.retryExecutor;
 
 /**
  * Created by takahiro.nakayama on 10/20/15.
@@ -44,8 +52,8 @@ public class SftpFileOutput
 
     private final int taskIndex;
     private int fileIndex = 0;
-    private FileObject currentFile;
-    private OutputStream currentFileOutputStream;
+    private File tempFile;
+    private BufferedOutputStream localOutput = null;
 
     private StandardFileSystemManager initializeStandardFileSystemManager()
     {
@@ -144,11 +152,10 @@ public class SftpFileOutput
         closeCurrentFile();
 
         try {
-            currentFile = newSftpFile(getSftpFileUri(getOutputFilePath()));
-            currentFileOutputStream = newSftpOutputStream(currentFile);
-            logger.info("new sftp file: {}", currentFile.getPublicURIString());
+            tempFile = Exec.getTempFileSpace().createTempFile();
+            localOutput = new BufferedOutputStream(new FileOutputStream(tempFile));
         }
-        catch (FileSystemException e) {
+        catch (FileNotFoundException e) {
             logger.error(e.getMessage());
             Throwables.propagate(e);
         }
@@ -157,28 +164,11 @@ public class SftpFileOutput
     @Override
     public void add(final Buffer buffer)
     {
-        if (currentFile == null) {
-            throw new IllegalStateException("nextFile() must be called before poll()");
-        }
-
         try {
-            Retriable<Void> retriable = new Retriable<Void>() {
-                public Void execute() throws IOException
-                {
-                    currentFileOutputStream.write(buffer.array(), buffer.offset(), buffer.limit());
-                    return null;
-                }
-            };
-            try {
-                withConnectionRetry(retriable);
-            }
-            catch (Exception e) {
-                throw (IOException) e;
-            }
+            localOutput.write(buffer.array(), buffer.offset(), buffer.limit());
         }
-        catch (IOException e) {
-            logger.error(e.getMessage());
-            Throwables.propagate(e);
+        catch (IOException ex) {
+            throw Throwables.propagate(ex);
         }
         finally {
             buffer.release();
@@ -189,6 +179,7 @@ public class SftpFileOutput
     public void finish()
     {
         closeCurrentFile();
+        uploadFile(getOutputFilePath());
     }
 
     @Override
@@ -211,27 +202,68 @@ public class SftpFileOutput
 
     private void closeCurrentFile()
     {
-        if (currentFile == null) {
-            return;
+        if (localOutput != null) {
+            try {
+                localOutput.close();
+            }
+            catch (IOException ex) {
+                throw Throwables.propagate(ex);
+            }
         }
+    }
 
+    private Void uploadFile(final String remotePath)
+    {
         try {
-            currentFileOutputStream.close();
-        }
-        catch (IOException e) {
-            logger.info(e.getMessage());
-        }
+            return retryExecutor()
+                    .withRetryLimit(maxConnectionRetry)
+                    .withInitialRetryWait(500)
+                    .withMaxRetryWait(30 * 1000)
+                    .runInterruptible(new Retryable<Void>() {
+                        @Override
+                        public Void call() throws InterruptedException, IOException, RetryGiveupException
+                        {
+                            FileObject remoteFile = newSftpFile(getSftpFileUri(remotePath));
+                            logger.info("new sftp file: {}", remoteFile.getPublicURIString());
+                            try (BufferedOutputStream outputStream = new BufferedOutputStream(remoteFile.getContent().getOutputStream())) {
+                                try (BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(tempFile))) {
+                                    IOUtils.copy(inputStream, outputStream);
+                                }
+                            }
+                            return null;
+                        }
 
-        try {
-            currentFile.close();
-        }
-        catch (FileSystemException e) {
-            logger.warn(e.getMessage());
-        }
+                        @Override
+                        public boolean isRetryableException(Exception exception)
+                        {
+                            return true;
+                        }
 
-        fileIndex++;
-        currentFile = null;
-        currentFileOutputStream = null;
+                        @Override
+                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait) throws RetryGiveupException
+                        {
+                            String message = String.format("SFTP output failed. Retrying %d/%d after %d seconds. Message: %s",
+                                    retryCount, retryLimit, retryWait / 1000, exception.getMessage());
+                            if (retryCount % 3 == 0) {
+                                logger.warn(message, exception);
+                            }
+                            else {
+                                logger.warn(message);
+                            }
+                        }
+
+                        @Override
+                        public void onGiveup(Exception firstException, Exception lastException) throws RetryGiveupException
+                        {
+                        }
+                    });
+        }
+        catch (RetryGiveupException ex) {
+            throw Throwables.propagate(ex.getCause());
+        }
+        catch (InterruptedException ex) {
+            throw Throwables.propagate(ex);
+        }
     }
 
     private URI getSftpFileUri(String remoteFilePath)
@@ -250,84 +282,54 @@ public class SftpFileOutput
         return pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + fileNameExtension;
     }
 
-    interface Retriable<T>
-    {
-        /**
-         * Execute the operation with the given (or null) return value.
-         * @return any return value from the operation
-         * @throws Exception
-         */
-        public T execute() throws Exception;
-    }
-
-    private <T> T withConnectionRetry(final Retriable<T> op)
-            throws Exception
-    {
-        int count = 0;
-        while (true) {
-            try {
-                return op.execute();
-            }
-            catch (final Exception e) {
-                if (++count > maxConnectionRetry) {
-                    throw e;
-                }
-                logger.warn("failed to connect sftp server: " + e.getMessage(), e);
-
-                try {
-                    long sleepTime = ((long) Math.pow(2, count) * 1000);
-                    logger.warn("sleep in next connection retry: {} milliseconds", sleepTime);
-                    Thread.sleep(sleepTime); // milliseconds
-                }
-                catch (InterruptedException e1) {
-                    // Ignore this exception because this exception is just about `sleep`.
-                    logger.warn(e1.getMessage(), e1);
-                }
-                logger.warn("retry to connect sftp server: " + count + " times");
-            }
-        }
-    }
-
     private FileObject newSftpFile(final URI sftpUri)
-            throws FileSystemException
+            throws FileSystemException, RetryGiveupException, InterruptedException
     {
-        Retriable<FileObject> retriable = new Retriable<FileObject>() {
-            public FileObject execute() throws FileSystemException
-            {
-                FileObject file = manager.resolveFile(sftpUri.toString(), fsOptions);
-                if (file.getParent().exists()) {
-                    logger.info("parent directory {} exists there", file.getParent().getPublicURIString());
-                }
-                else {
-                    logger.info("trying to create parent directory {}", file.getParent().getPublicURIString());
-                    file.getParent().createFolder();
-                }
-                return file;
-            }
-        };
-        try {
-            return withConnectionRetry(retriable);
-        }
-        catch (Exception e) {
-            throw (FileSystemException) e;
-        }
-    }
+        return retryExecutor()
+                .withRetryLimit(maxConnectionRetry)
+                .withInitialRetryWait(500)
+                .withMaxRetryWait(30 * 1000)
+                .runInterruptible(new Retryable<FileObject>() {
+                    @Override
+                    public FileObject call() throws FileSystemException, RetryGiveupException
+                    {
+                        FileObject file = manager.resolveFile(sftpUri.toString(), fsOptions);
+                        if (file.getParent().exists()) {
+                            logger.info("parent directory {} exists there", file.getParent().getPublicURIString());
+                        }
+                        else {
+                            logger.info("trying to create parent directory {}", file.getParent().getPublicURIString());
+                            file.getParent().createFolder();
+                        }
+                        return file;
+                    }
 
-    private OutputStream newSftpOutputStream(final FileObject file)
-            throws FileSystemException
-    {
-        Retriable<OutputStream> retriable = new Retriable<OutputStream>() {
-            public OutputStream execute() throws FileSystemException
-            {
-                return file.getContent().getOutputStream();
-            }
-        };
-        try {
-            return withConnectionRetry(retriable);
-        }
-        catch (Exception e) {
-            throw (FileSystemException) e;
-        }
+                    @Override
+                    public boolean isRetryableException(Exception exception)
+                    {
+                        return true;
+                    }
+
+                    @Override
+                    public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+                            throws RetryGiveupException
+                    {
+                        String message = String.format("SFTP resolve file request failed. Retrying %d/%d after %d seconds. Message: %s",
+                                retryCount, retryLimit, retryWait / 1000, exception.getMessage());
+                        if (retryCount % 3 == 0) {
+                            logger.warn(message, exception);
+                        }
+                        else {
+                            logger.warn(message);
+                        }
+                    }
+
+                    @Override
+                    public void onGiveup(Exception firstException, Exception lastException)
+                            throws RetryGiveupException
+                    {
+                    }
+                });
     }
 
     private Function<LocalFile, String> localFileToPathString()


### PR DESCRIPTION
This plugin sometimes fails while writing to OutputStream.

## Problem
Currently, plugin opens OutputStream at `nextFile()` and write buffer at `add()`.
This implementation is hard to retry because plugin never knows how many buffers were written  
 at remote file when failure happens.
```java
@Override
public void nextFile()
{
    ...
    # Open OutputStream
    currentFileOutputStream = newSftpOutputStream(currentFile);
    ...
}

@Override
public void add(final Buffer buffer)
{
    Retriable<Void> retriable = new Retriable<Void>() {
        public Void execute() throws IOException
        {
            # Write to OutputStream
            currentFileOutputStream.write(buffer.array(), buffer.offset(), buffer.limit());
            ...
        }
    };
}
```

## What I changed

### Write at local temporary file first
1. Write at local temporary file at first
2. Read from temporary file and copy to OutputStream
3. Retry 2 when something failure happens
    * At this time, plugin will read temporary file from first and write again into OutputStream. Then, result has idempotency.

### Use RetryExecutor
Current implementation uses own retry logic. I also changed to use RetryExcecutor.

## Stacktrace of failure
```
2017-03-15 13:11:25.491 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-sftp (0.0.9)
2017-03-15 13:11:25.661 +0000 [INFO] (0001:transaction): Listing local files at directory '/path/to/somewhere' filtering filename by prefix 'result'
2017-03-15 13:11:25.665 +0000 [INFO] (0001:transaction): Loading files [/path/to/somewhere]
2017-03-15 13:11:25.723 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=32 / tasks=1
2017-03-15 13:11:25.776 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2017-03-15 13:11:26.419 +0000 [INFO] (0013:task-0000): parent directory sftp://user:***@example.com/dir exists there
2017-03-15 13:11:26.474 +0000 [INFO] (0013:task-0000): new sftp file: sftp://user:***@example.com/dir/output.csv
2017-03-15 13:11:49.726 +0000 [WARN] (0013:task-0000): failed to connect sftp server: Connection reset
java.net.SocketException: Connection reset
	at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:118) ~[na:1.7.0_80]
	at java.net.SocketOutputStream.write(SocketOutputStream.java:159) ~[na:1.7.0_80]
	at com.jcraft.jsch.IO.put(IO.java:60) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.Session._write(Session.java:1368) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.Session.write(Session.java:1335) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp.sendWRITE(ChannelSftp.java:2619) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp.access$100(ChannelSftp.java:36) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp$1.write(ChannelSftp.java:791) ~[jsch-0.1.53.jar:na]
	at java.io.BufferedOutputStream.write(BufferedOutputStream.java:122) ~[na:1.7.0_80]
	at org.apache.commons.vfs2.util.MonitorOutputStream.write(MonitorOutputStream.java:123) ~[commons-vfs2-2.1.1660580.2.jar:2.1.1660580.2]
	at java.io.BufferedOutputStream.write(BufferedOutputStream.java:122) ~[na:1.7.0_80]
	at org.apache.commons.vfs2.util.MonitorOutputStream.write(MonitorOutputStream.java:123) ~[commons-vfs2-2.1.1660580.2.jar:2.1.1660580.2]
	at org.embulk.output.sftp.SftpFileOutput$1.execute(SftpFileOutput.java:168) ~[embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput$1.execute(SftpFileOutput.java:165) ~[embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.withConnectionRetry(SftpFileOutput.java:269) [embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.add(SftpFileOutput.java:173) [embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.doFlush(FileOutputOutputStream.java:79) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.flush(FileOutputOutputStream.java:90) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.write(FileOutputOutputStream.java:63) [embulk-core-0.8.18.jar:na]
	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:282) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.write(StreamEncoder.java:125) [na:1.7.0_80]
	at java.io.OutputStreamWriter.write(OutputStreamWriter.java:207) [na:1.7.0_80]
	at java.io.BufferedWriter.flushBuffer(BufferedWriter.java:129) [na:1.7.0_80]
	at java.io.BufferedWriter.write(BufferedWriter.java:230) [na:1.7.0_80]
	at java.io.Writer.write(Writer.java:157) [na:1.7.0_80]
	at java.io.Writer.append(Writer.java:227) [na:1.7.0_80]
	at org.embulk.spi.util.LineEncoder.addText(LineEncoder.java:78) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.addDelimiter(CsvFormatterPlugin.java:197) [embulk-standards-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.stringColumn(CsvFormatterPlugin.java:164) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.Column.visit(Column.java:58) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.Schema.visitColumns(Schema.java:81) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1.add(CsvFormatterPlugin.java:131) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.add(FileOutputRunner.java:166) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:244) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.flush(PageBuilder.java:250) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.addRecord(PageBuilder.java:227) [embulk-core-0.8.18.jar:na]
	at org.embulk.parser.msgpack.MsgpackParserPlugin.run(MsgpackParserPlugin.java:280) [embulk-parser-msgpack-0.2.2.jar:na]
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:153) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:67) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:42) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180) [embulk-core-0.8.18.jar:na]
	at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_80]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_80]
2017-03-15 13:11:49.726 +0000 [WARN] (0013:task-0000): sleep in next connection retry: 2000 milliseconds
2017-03-15 13:11:51.727 +0000 [WARN] (0013:task-0000): retry to connect sftp server: 1 times
2017-03-15 13:11:52.794 +0000 [WARN] (0013:task-0000): failed to connect sftp server: channel is broken
java.io.IOException: channel is broken
	at com.jcraft.jsch.Session.write(Session.java:1281) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp.sendWRITE(ChannelSftp.java:2619) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp.access$100(ChannelSftp.java:36) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp$1.write(ChannelSftp.java:791) ~[jsch-0.1.53.jar:na]
	at java.io.BufferedOutputStream.write(BufferedOutputStream.java:122) ~[na:1.7.0_80]
	at org.apache.commons.vfs2.util.MonitorOutputStream.write(MonitorOutputStream.java:123) ~[commons-vfs2-2.1.1660580.2.jar:2.1.1660580.2]
	at java.io.BufferedOutputStream.write(BufferedOutputStream.java:122) ~[na:1.7.0_80]
	at org.apache.commons.vfs2.util.MonitorOutputStream.write(MonitorOutputStream.java:123) ~[commons-vfs2-2.1.1660580.2.jar:2.1.1660580.2]
	at org.embulk.output.sftp.SftpFileOutput$1.execute(SftpFileOutput.java:168) ~[embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput$1.execute(SftpFileOutput.java:165) ~[embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.withConnectionRetry(SftpFileOutput.java:269) [embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.add(SftpFileOutput.java:173) [embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.doFlush(FileOutputOutputStream.java:79) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.flush(FileOutputOutputStream.java:90) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.write(FileOutputOutputStream.java:63) [embulk-core-0.8.18.jar:na]
	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:282) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.write(StreamEncoder.java:125) [na:1.7.0_80]
	at java.io.OutputStreamWriter.write(OutputStreamWriter.java:207) [na:1.7.0_80]
	at java.io.BufferedWriter.flushBuffer(BufferedWriter.java:129) [na:1.7.0_80]
	at java.io.BufferedWriter.write(BufferedWriter.java:230) [na:1.7.0_80]
	at java.io.Writer.write(Writer.java:157) [na:1.7.0_80]
	at java.io.Writer.append(Writer.java:227) [na:1.7.0_80]
	at org.embulk.spi.util.LineEncoder.addText(LineEncoder.java:78) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.addValue(CsvFormatterPlugin.java:203) [embulk-standards-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.stringColumn(CsvFormatterPlugin.java:166) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.Column.visit(Column.java:58) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.Schema.visitColumns(Schema.java:81) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1.add(CsvFormatterPlugin.java:131) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.add(FileOutputRunner.java:166) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:244) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.flush(PageBuilder.java:250) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.addRecord(PageBuilder.java:227) [embulk-core-0.8.18.jar:na]
	at org.embulk.parser.msgpack.MsgpackParserPlugin.run(MsgpackParserPlugin.java:280) [embulk-parser-msgpack-0.2.2.jar:na]
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:153) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:67) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:42) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180) [embulk-core-0.8.18.jar:na]
	at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_80]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_80]
2017-03-15 13:11:42.795 +0000 [WARN] (0013:task-0000): sleep in next connection retry: 2000 milliseconds
2017-03-15 13:11:44.795 +0000 [WARN] (0013:task-0000): retry to connect sftp server: 1 times
2017-03-15 13:11:44.896 +0000 [WARN] (0013:task-0000): failed to connect sftp server: channel is broken
java.io.IOException: channel is broken
	at com.jcraft.jsch.Session.write(Session.java:1281) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp.sendWRITE(ChannelSftp.java:2619) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp.access$100(ChannelSftp.java:36) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp$1.write(ChannelSftp.java:791) ~[jsch-0.1.53.jar:na]
	at java.io.BufferedOutputStream.write(BufferedOutputStream.java:122) ~[na:1.7.0_80]
	at org.apache.commons.vfs2.util.MonitorOutputStream.write(MonitorOutputStream.java:123) ~[commons-vfs2-2.1.1660580.2.jar:2.1.1660580.2]
	at java.io.BufferedOutputStream.write(BufferedOutputStream.java:122) ~[na:1.7.0_80]
	at org.apache.commons.vfs2.util.MonitorOutputStream.write(MonitorOutputStream.java:123) ~[commons-vfs2-2.1.1660580.2.jar:2.1.1660580.2]
	at org.embulk.output.sftp.SftpFileOutput$1.execute(SftpFileOutput.java:168) ~[embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput$1.execute(SftpFileOutput.java:165) ~[embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.withConnectionRetry(SftpFileOutput.java:269) [embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.add(SftpFileOutput.java:173) [embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.doFlush(FileOutputOutputStream.java:79) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.flush(FileOutputOutputStream.java:90) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.write(FileOutputOutputStream.java:63) [embulk-core-0.8.18.jar:na]
	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:282) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.write(StreamEncoder.java:125) [na:1.7.0_80]
	at java.io.OutputStreamWriter.write(OutputStreamWriter.java:207) [na:1.7.0_80]
	at java.io.BufferedWriter.flushBuffer(BufferedWriter.java:129) [na:1.7.0_80]
	at java.io.BufferedWriter.write(BufferedWriter.java:230) [na:1.7.0_80]
	at java.io.Writer.write(Writer.java:157) [na:1.7.0_80]
	at java.io.Writer.append(Writer.java:227) [na:1.7.0_80]
	at org.embulk.spi.util.LineEncoder.addText(LineEncoder.java:78) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.addValue(CsvFormatterPlugin.java:203) [embulk-standards-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.stringColumn(CsvFormatterPlugin.java:166) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.Column.visit(Column.java:58) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.Schema.visitColumns(Schema.java:81) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1.add(CsvFormatterPlugin.java:131) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.add(FileOutputRunner.java:166) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:244) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.flush(PageBuilder.java:250) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.addRecord(PageBuilder.java:227) [embulk-core-0.8.18.jar:na]
	at org.embulk.parser.msgpack.MsgpackParserPlugin.run(MsgpackParserPlugin.java:280) [embulk-parser-msgpack-0.2.2.jar:na]
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:153) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:67) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:42) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180) [embulk-core-0.8.18.jar:na]
	at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_80]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_80]
2017-03-15 13:11:54.896 +0000 [WARN] (0013:task-0000): sleep in next connection retry: 4000 milliseconds
2017-03-15 13:11:58.896 +0000 [WARN] (0013:task-0000): retry to connect sftp server: 2 times
2017-03-15 13:11:58.997 +0000 [WARN] (0013:task-0000): failed to connect sftp server: channel is broken
java.io.IOException: channel is broken
	at com.jcraft.jsch.Session.write(Session.java:1281) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp.sendWRITE(ChannelSftp.java:2619) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp.access$100(ChannelSftp.java:36) ~[jsch-0.1.53.jar:na]
	at com.jcraft.jsch.ChannelSftp$1.write(ChannelSftp.java:791) ~[jsch-0.1.53.jar:na]
	at java.io.BufferedOutputStream.write(BufferedOutputStream.java:122) ~[na:1.7.0_80]
	at org.apache.commons.vfs2.util.MonitorOutputStream.write(MonitorOutputStream.java:123) ~[commons-vfs2-2.1.1660580.2.jar:2.1.1660580.2]
	at java.io.BufferedOutputStream.write(BufferedOutputStream.java:122) ~[na:1.7.0_80]
	at org.apache.commons.vfs2.util.MonitorOutputStream.write(MonitorOutputStream.java:123) ~[commons-vfs2-2.1.1660580.2.jar:2.1.1660580.2]
	at org.embulk.output.sftp.SftpFileOutput$1.execute(SftpFileOutput.java:168) ~[embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput$1.execute(SftpFileOutput.java:165) ~[embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.withConnectionRetry(SftpFileOutput.java:269) [embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.output.sftp.SftpFileOutput.add(SftpFileOutput.java:173) [embulk-output-sftp-0.0.9.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.doFlush(FileOutputOutputStream.java:79) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.flush(FileOutputOutputStream.java:90) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.FileOutputOutputStream.write(FileOutputOutputStream.java:63) [embulk-core-0.8.18.jar:na]
	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:282) [na:1.7.0_80]
	at sun.nio.cs.StreamEncoder.write(StreamEncoder.java:125) [na:1.7.0_80]
	at java.io.OutputStreamWriter.write(OutputStreamWriter.java:207) [na:1.7.0_80]
	at java.io.BufferedWriter.flushBuffer(BufferedWriter.java:129) [na:1.7.0_80]
	at java.io.BufferedWriter.write(BufferedWriter.java:230) [na:1.7.0_80]
	at java.io.Writer.write(Writer.java:157) [na:1.7.0_80]
	at java.io.Writer.append(Writer.java:227) [na:1.7.0_80]
	at org.embulk.spi.util.LineEncoder.addText(LineEncoder.java:78) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.addValue(CsvFormatterPlugin.java:203) [embulk-standards-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1$1.stringColumn(CsvFormatterPlugin.java:166) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.Column.visit(Column.java:58) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.Schema.visitColumns(Schema.java:81) [embulk-core-0.8.18.jar:na]
	at org.embulk.standards.CsvFormatterPlugin$1.add(CsvFormatterPlugin.java:131) [embulk-standards-0.8.18.jar:na]
	at org.embulk.spi.FileOutputRunner$DelegateTransactionalPageOutput.add(FileOutputRunner.java:166) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:244) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.flush(PageBuilder.java:250) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.PageBuilder.addRecord(PageBuilder.java:227) [embulk-core-0.8.18.jar:na]
	at org.embulk.parser.msgpack.MsgpackParserPlugin.run(MsgpackParserPlugin.java:280) [embulk-parser-msgpack-0.2.2.jar:na]
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:153) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:67) [embulk-core-0.8.18.jar:na]
	at org.embulk.spi.util.Executors.process(Executors.java:42) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184) [embulk-core-0.8.18.jar:na]
	at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180) [embulk-core-0.8.18.jar:na]
	at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_80]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_80]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_80]
```