### PR TITLE
Fix bug: Increment fileIndex after complete uploadFile

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -180,6 +180,7 @@ public class SftpFileOutput
     {
         closeCurrentFile();
         uploadFile(getOutputFilePath());
+        fileIndex++;
     }
 
     @Override


### PR DESCRIPTION
Current implementation don't increment `fileIndex`. This don't affect when each task only output 1 file.
However, file name will be conflicted when task generates multiple files.

I added increment logic at `SftpFileOutput.finish` instead of `SftpFileOutput.nextFile` since `SftpFileOutput` class set `fileIndex=0` [when initialized](https://github.com/embulk/embulk-output-sftp/pull/35/files#diff-224baa6e670e84c6b9619558173f980dR54).