### PR TITLE
Use host addon and set `dist:precise` to avoid Travis CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: java
 jdk:
   - openjdk7
@@ -7,3 +8,7 @@ script:
   - ./gradlew test
 after_success:
   - ./gradlew jacocoTestReport coveralls
+addons:
+  hosts:
+    - example.com
+  hostname: example.com


### PR DESCRIPTION
Use host addon & Set dist: precise for fixing tests. See the below refs.

ref. https://github.com/civitaspo/embulk-filter-expand_json/pull/34