### PR TITLE
Disable remote temporary file rename logic

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -84,7 +84,12 @@ public class SftpFileOutput
         closeCurrentFile();
         String fileName = getOutputFilePath();
         String temporaryFileName = fileName + temporaryFileSuffix;
-        sftpUtils.uploadFile(tempFile, temporaryFileName);
+        /*
+          #37 causes permission failure while renaming remote file.
+          https://github.com/embulk/embulk-output-sftp/issues/40
+         */
+        //sftpUtils.uploadFile(tempFile, temporaryFileName);
+        sftpUtils.uploadFile(tempFile, fileName);
 
         Map<String, String> executedFiles = new HashMap<>();
         executedFiles.put("temporary_filename", temporaryFileName);

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -14,7 +14,6 @@ import org.embulk.spi.TransactionalFileOutput;
 import org.embulk.spi.unit.LocalFile;
 
 import java.util.List;
-import java.util.Map;
 
 public class SftpFileOutputPlugin
         implements FileOutputPlugin
@@ -99,17 +98,21 @@ public class SftpFileOutputPlugin
             int taskCount,
             List<TaskReport> successTaskReports)
     {
-        SftpUtils sftpUtils = new SftpUtils(taskSource.loadTask(PluginTask.class));
-        for (TaskReport report : successTaskReports) {
-            List<Map<String, String>> moveFileList = report.get(List.class, "file_list");
-            for (Map<String, String> pairFiles : moveFileList) {
-                String temporaryFileName = pairFiles.get("temporary_filename");
-                String realFileName = pairFiles.get("real_filename");
-
-                sftpUtils.renameFile(temporaryFileName, realFileName);
-            }
-        }
-        sftpUtils.close();
+        /*
+          #37 causes permission failure while renaming remote file.
+          https://github.com/embulk/embulk-output-sftp/issues/40
+         */
+//        SftpUtils sftpUtils = new SftpUtils(taskSource.loadTask(PluginTask.class));
+//        for (TaskReport report : successTaskReports) {
+//            List<Map<String, String>> moveFileList = report.get(List.class, "file_list");
+//            for (Map<String, String> pairFiles : moveFileList) {
+//                String temporaryFileName = pairFiles.get("temporary_filename");
+//                String realFileName = pairFiles.get("real_filename");
+//
+//                sftpUtils.renameFile(temporaryFileName, realFileName);
+//            }
+//        }
+//        sftpUtils.close();
     }
 
     @Override


### PR DESCRIPTION
Related to #40 
I once disabled remote temporary file rename logic.
This feature sometimes fails due to permission failure.