### PR TITLE
[Re-implement] Upload with ".tmp" suffix and rename file name after upload

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -30,6 +30,7 @@ public class SftpFileOutput
     private final String pathPrefix;
     private final String sequenceFormat;
     private final String fileNameExtension;
+    private final boolean renameFileAfterUpload;
 
     private final int taskIndex;
     private final SftpUtils sftpUtils;
@@ -45,6 +46,7 @@ public class SftpFileOutput
         this.pathPrefix = task.getPathPrefix();
         this.sequenceFormat = task.getSequenceFormat();
         this.fileNameExtension = task.getFileNameExtension();
+        this.renameFileAfterUpload = task.getRenameFileAfterUpload();
         this.taskIndex = taskIndex;
         this.sftpUtils = new SftpUtils(task);
     }
@@ -84,7 +86,12 @@ public class SftpFileOutput
         closeCurrentFile();
         String fileName = getOutputFilePath();
         String temporaryFileName = fileName + temporaryFileSuffix;
-        sftpUtils.uploadFile(tempFile, temporaryFileName);
+        if (renameFileAfterUpload) {
+            sftpUtils.uploadFile(tempFile, temporaryFileName);
+        }
+        else {
+            sftpUtils.uploadFile(tempFile, fileName);
+        }
 
         Map<String, String> executedFiles = new HashMap<>();
         executedFiles.put("temporary_filename", temporaryFileName);

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -84,12 +84,7 @@ public class SftpFileOutput
         closeCurrentFile();
         String fileName = getOutputFilePath();
         String temporaryFileName = fileName + temporaryFileSuffix;
-        /*
-          #37 causes permission failure while renaming remote file.
-          https://github.com/embulk/embulk-output-sftp/issues/40
-         */
-        //sftpUtils.uploadFile(tempFile, temporaryFileName);
-        sftpUtils.uploadFile(tempFile, fileName);
+        sftpUtils.uploadFile(tempFile, temporaryFileName);
 
         Map<String, String> executedFiles = new HashMap<>();
         executedFiles.put("temporary_filename", temporaryFileName);

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -14,6 +14,7 @@ import org.embulk.spi.TransactionalFileOutput;
 import org.embulk.spi.unit.LocalFile;
 
 import java.util.List;
+import java.util.Map;
 
 public class SftpFileOutputPlugin
         implements FileOutputPlugin
@@ -98,21 +99,24 @@ public class SftpFileOutputPlugin
             int taskCount,
             List<TaskReport> successTaskReports)
     {
-        /*
-          #37 causes permission failure while renaming remote file.
-          https://github.com/embulk/embulk-output-sftp/issues/40
-         */
-//        SftpUtils sftpUtils = new SftpUtils(taskSource.loadTask(PluginTask.class));
-//        for (TaskReport report : successTaskReports) {
-//            List<Map<String, String>> moveFileList = report.get(List.class, "file_list");
-//            for (Map<String, String> pairFiles : moveFileList) {
-//                String temporaryFileName = pairFiles.get("temporary_filename");
-//                String realFileName = pairFiles.get("real_filename");
-//
-//                sftpUtils.renameFile(temporaryFileName, realFileName);
-//            }
-//        }
-//        sftpUtils.close();
+        SftpUtils sftpUtils = null;
+        try {
+            new SftpUtils(taskSource.loadTask(PluginTask.class));
+            for (TaskReport report : successTaskReports) {
+                List<Map<String, String>> moveFileList = report.get(List.class, "file_list");
+                for (Map<String, String> pairFiles : moveFileList) {
+                    String temporaryFileName = pairFiles.get("temporary_filename");
+                    String realFileName = pairFiles.get("real_filename");
+
+                    sftpUtils.renameFile(temporaryFileName, realFileName);
+                }
+            }
+        }
+        finally {
+            if (sftpUtils != null) {
+                sftpUtils.close();
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
This is a revise of #37 

Some MA tools are polling if remote files with specific file name exists at SFTP server and will import it when file exists. In this case, MA tool doesn't know if Embulk output process is already completed or not.
With this feature, plugin will upload "*.tmp" file first, and rename them to "*.csv"(or something) after upload finishes.

I changed implementation to set temporary_filename and real_filename to Embulk TaskReport at SftpFileOutput.commit().
After all tasks completed, plugin will get each file name sets and rename remote files.
Of course, temporary file will be left in remote server "/path/to/file.txt.tmp".
However, this is help full for simple mechanical check.

I created another PR #44  since Apache Commons VFS2 is checking parent directory's permission with SSH when rename and it should cause permission failure #40  if command execution over SSH isn't permitted for SFTP account.