### PR TITLE
Implement original SFTP provider for Apache Commons VFS2

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -6,7 +6,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.impl.StandardFileSystemManager;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
 import org.apache.commons.vfs2.provider.sftp.IdentityInfo;
 import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
 import org.embulk.config.ConfigException;
@@ -33,21 +33,27 @@ import static org.embulk.spi.util.RetryExecutor.retryExecutor;
 public class SftpUtils
 {
     private final Logger logger = Exec.getLogger(SftpUtils.class);
-    private final StandardFileSystemManager manager;
+    private final DefaultFileSystemManager manager;
     private final FileSystemOptions fsOptions;
     private final String userInfo;
     private final String host;
     private final int port;
     private final int maxConnectionRetry;
 
-    private StandardFileSystemManager initializeStandardFileSystemManager()
+    private DefaultFileSystemManager initializeStandardFileSystemManager()
     {
         if (!logger.isDebugEnabled()) {
             // TODO: change logging format: org.apache.commons.logging.Log
             System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.NoOpLog");
         }
-        StandardFileSystemManager manager = new StandardFileSystemManager();
-        manager.setClassLoader(SftpUtils.class.getClassLoader());
+        /*
+         * We can use StandardFileSystemManager instead of DefaultFileSystemManager
+         * when Apache Commons VFS2 removes permission check logic when remote file renaming.
+         * https://github.com/embulk/embulk-output-sftp/issues/40
+         * https://github.com/embulk/embulk-output-sftp/pull/44
+         * https://issues.apache.org/jira/browse/VFS-590
+        */
+        DefaultFileSystemManager manager = new DefaultFileSystemManager();
         try {
             manager.addProvider("sftp", new org.embulk.output.sftp.provider.sftp.SftpFileProvider());
             manager.init();

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -49,6 +49,7 @@ public class SftpUtils
         StandardFileSystemManager manager = new StandardFileSystemManager();
         manager.setClassLoader(SftpUtils.class.getClassLoader());
         try {
+            manager.addProvider("sftp", new org.embulk.output.sftp.provider.sftp.SftpFileProvider());
             manager.init();
         }
         catch (FileSystemException e) {

--- a/src/main/java/org/embulk/output/sftp/provider/sftp/SftpFileObject.java
+++ b/src/main/java/org/embulk/output/sftp/provider/sftp/SftpFileObject.java
@@ -39,6 +39,6 @@ public class SftpFileObject extends org.apache.commons.vfs2.provider.sftp.SftpFi
     @Override
     protected boolean doIsWriteable() throws Exception
     {
-        return getPermissions(true).isWritable();
+        return true;
     }
 }

--- a/src/main/java/org/embulk/output/sftp/provider/sftp/SftpFileObject.java
+++ b/src/main/java/org/embulk/output/sftp/provider/sftp/SftpFileObject.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.embulk.output.sftp.provider.sftp;
+
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystem;
+
+/*
+ * We can remove this file when Apache Commons VFS2 removes permission check logic when remote file renaming.
+ * https://github.com/embulk/embulk-output-sftp/issues/40
+ * https://github.com/embulk/embulk-output-sftp/pull/44
+ * https://issues.apache.org/jira/browse/VFS-590
+ */
+/**
+ * An SFTP file.
+ */
+public class SftpFileObject extends org.apache.commons.vfs2.provider.sftp.SftpFileObject
+{
+    protected SftpFileObject(final AbstractFileName name, final SftpFileSystem fileSystem) throws FileSystemException
+    {
+        super(name, fileSystem);
+    }
+
+    @Override
+    protected boolean doIsWriteable() throws Exception
+    {
+        return getPermissions(true).isWritable();
+    }
+}

--- a/src/main/java/org/embulk/output/sftp/provider/sftp/SftpFileProvider.java
+++ b/src/main/java/org/embulk/output/sftp/provider/sftp/SftpFileProvider.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.embulk.output.sftp.provider.sftp;
+
+import com.jcraft.jsch.Session;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.UserAuthenticationData;
+import org.apache.commons.vfs2.provider.GenericFileName;
+import org.apache.commons.vfs2.provider.sftp.SftpClientFactory;
+import org.apache.commons.vfs2.util.UserAuthenticatorUtils;
+
+/*
+ * We can remove this file when Apache Commons VFS2 removes permission check logic when remote file renaming.
+ * https://github.com/embulk/embulk-output-sftp/issues/40
+ * https://github.com/embulk/embulk-output-sftp/pull/44
+ * https://issues.apache.org/jira/browse/VFS-590
+ */
+/**
+ * A provider for accessing files over SFTP.
+ */
+public class SftpFileProvider extends org.apache.commons.vfs2.provider.sftp.SftpFileProvider
+{
+    /**
+     * Constructs a new provider.
+     */
+    public SftpFileProvider()
+    {
+        super();
+    }
+
+    /**
+     * Creates a {@link FileSystem}.
+     */
+    @Override
+    protected FileSystem doCreateFileSystem(final FileName name, final FileSystemOptions fileSystemOptions)
+            throws FileSystemException
+    {
+        // JSch jsch = createJSch(fileSystemOptions);
+
+        // Create the file system
+        final GenericFileName rootName = (GenericFileName) name;
+
+        Session session;
+        UserAuthenticationData authData = null;
+        try {
+            authData = UserAuthenticatorUtils.authenticate(fileSystemOptions, AUTHENTICATOR_TYPES);
+
+            session = SftpClientFactory.createConnection(rootName.getHostName(), rootName.getPort(),
+                    UserAuthenticatorUtils.getData(authData, UserAuthenticationData.USERNAME,
+                            UserAuthenticatorUtils.toChar(rootName.getUserName())),
+                    UserAuthenticatorUtils.getData(authData, UserAuthenticationData.PASSWORD,
+                            UserAuthenticatorUtils.toChar(rootName.getPassword())),
+                    fileSystemOptions);
+        }
+        catch (final Exception e) {
+            throw new FileSystemException("vfs.provider.sftp/connect.error", name, e);
+        }
+        finally {
+            UserAuthenticatorUtils.cleanup(authData);
+        }
+
+        return new SftpFileSystem(rootName, session, fileSystemOptions);
+    }
+}

--- a/src/main/java/org/embulk/output/sftp/provider/sftp/SftpFileSystem.java
+++ b/src/main/java/org/embulk/output/sftp/provider/sftp/SftpFileSystem.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.embulk.output.sftp.provider.sftp;
+
+import com.jcraft.jsch.Session;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.GenericFileName;
+
+/*
+ * We can remove this file when Apache Commons VFS2 removes permission check logic when remote file renaming.
+ * https://github.com/embulk/embulk-output-sftp/issues/40
+ * https://github.com/embulk/embulk-output-sftp/pull/44
+ * https://issues.apache.org/jira/browse/VFS-590
+ */
+/**
+ * Represents the files on an SFTP server.
+ */
+public class SftpFileSystem extends org.apache.commons.vfs2.provider.sftp.SftpFileSystem
+{
+    protected SftpFileSystem(final GenericFileName rootName, final Session session,
+                             final FileSystemOptions fileSystemOptions)
+    {
+        super(rootName, null, fileSystemOptions);
+    }
+
+    /**
+     * Creates a file object. This method is called only if the requested file is not cached.
+     */
+    @Override
+    protected FileObject createFile(final AbstractFileName name) throws FileSystemException
+    {
+        return new SftpFileObject(name, this);
+    }
+}

--- a/src/main/java/org/embulk/output/sftp/provider/sftp/package.html
+++ b/src/main/java/org/embulk/output/sftp/provider/sftp/package.html
@@ -1,0 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+         http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<body>
+<p>The SFTP Provider.</p>
+</body>

--- a/src/main/resources/providers.xml
+++ b/src/main/resources/providers.xml
@@ -1,0 +1,29 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!--
+    We can remove this file when Apache Commons VFS2 removes permission check logic when remote file renaming.
+    https://github.com/embulk/embulk-output-sftp/issues/40
+    https://github.com/embulk/embulk-output-sftp/pull/44
+    https://issues.apache.org/jira/browse/VFS-590
+-->
+<providers>
+    <provider class-name="org.embulk.output.sftp.provider.sftp.SftpFileProvider">
+        <scheme name="sftp"/>
+        <if-available class-name="javax.crypto.Cipher"/>
+        <if-available class-name="com.jcraft.jsch.JSch"/>
+    </provider>
+</providers>


### PR DESCRIPTION
Follow up for #43 

I implemented original SFTP provider based on `org.apache.commons.vfs2.provider.sftp/*` to disable permission check logic before renaming remote files.
Apache Commons VFS2 is checking parent directory's permission.
This works if SFTP account can execute command over SSH. But doesn't works when command execution isn't permitted. #40 
https://issues.apache.org/jira/browse/VFS-590

`src/main/java/org/embulk/output/sftp/provider/*` implementation is almost same with SFTP provider in Apache Commons VFS2.
Main change is af1819a

Additionally, I changed `org.apache.commons.vfs2.impl.StandardFileSystemManager` to `org.apache.commons.vfs2.impl.DefaultFileSystemManager`. 
I faced ClassLoader problem and can't pass my original `providers.xml` to `StandardFileSystemmanager`.

We can remove these files when [VFS-590](https://issues.apache.org/jira/browse/VFS-590) is solved.