### PR TITLE
Add validation for "host" and "proxy.host"

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -81,6 +81,16 @@ public class SftpFileOutputPlugin
             FileOutputPlugin.Control control)
     {
         PluginTask task = config.loadConfig(PluginTask.class);
+        SftpUtils sftpUtils = null;
+        try {
+            sftpUtils = new SftpUtils(task);
+            sftpUtils.validateHost(task);
+        }
+        finally {
+            if (sftpUtils != null) {
+                sftpUtils.close();
+            }
+        }
 
         // retryable (idempotent) output:
         // return resume(task.dump(), taskCount, control);

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -264,6 +264,20 @@ public class SftpUtils
         }
     }
 
+    public void validateHost(PluginTask task)
+    {
+        if (task.getHost().contains("%s")) {
+            throw new ConfigException("'host' can't contain spaces");
+        }
+        getSftpFileUri("/");
+
+        if (task.getProxy().isPresent() && task.getProxy().get().getHost().isPresent()) {
+            if (task.getProxy().get().getHost().get().contains("%s")) {
+                throw new ConfigException("'proxy.host' can't contains spaces");
+            }
+        }
+    }
+
     private URI getSftpFileUri(String remoteFilePath)
     {
         try {

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -35,6 +35,7 @@ public class SftpUtils
     private final DefaultFileSystemManager manager;
     private final FileSystemOptions fsOptions;
     private final String userInfo;
+    private final String user;
     private final String host;
     private final int port;
     private final int maxConnectionRetry;
@@ -127,6 +128,7 @@ public class SftpUtils
     {
         this.manager = initializeStandardFileSystemManager();
         this.userInfo = initializeUserInfo(task);
+        this.user = task.getUser();
         this.fsOptions = initializeFsOptions(task);
         this.host = task.getHost();
         this.port = task.getPort();
@@ -284,8 +286,8 @@ public class SftpUtils
             return new URI("sftp", userInfo, host, port, remoteFilePath, null, null);
         }
         catch (URISyntaxException e) {
-            logger.error(e.getMessage());
-            throw new ConfigException(e);
+            String message = String.format("URISyntaxException was thrown: Illegal character in sftp://%s:******@%s:%s%s", user, host, port, remoteFilePath);
+            throw new ConfigException(message);
         }
     }
 

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -184,6 +184,9 @@ public class SftpUtils
                         @Override
                         public boolean isRetryableException(Exception exception)
                         {
+                            if (exception instanceof ConfigException) {
+                                return false;
+                            }
                             return true;
                         }
 

--- a/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
@@ -247,6 +247,37 @@ public class TestSftpFileOutputPlugin
         }
     }
 
+    @Test(expected = ConfigException.class)
+    public void testInvalidHost()
+    {
+        // setting embulk config
+        final String pathPrefix = "/test/testUserPassword";
+        String configYaml = "" +
+                "type: sftp\n" +
+                "host: " + HOST + "\n" +
+                "user: " + USERNAME + "\n" +
+                "path_prefix: " + pathPrefix + "\n" +
+                "file_ext: txt\n" +
+                "formatter:\n" +
+                "  type: csv\n" +
+                "  newline: CRLF\n" +
+                "  newline_in_field: LF\n" +
+                "  header_line: true\n" +
+                "  charset: UTF-8\n" +
+                "  quote_policy: NONE\n" +
+                "  quote: \"\\\"\"\n" +
+                "  escape: \"\\\\\"\n" +
+                "  null_string: \"\"\n" +
+                "  default_timezone: 'UTC'";
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+        config.set("host", HOST + " ");
+        PluginTask task = config.loadConfig(PluginTask.class);
+
+        SftpUtils utils = new SftpUtils(task);
+        utils.validateHost(task);
+    }
+
     @Test
     public void testConfigValuesIncludingDefault()
     {


### PR DESCRIPTION
This PR added validation for `host` and `proxy.host`.
Plugin doesn't check if these values contains empty chars or not.

And also fixed related 2 problems
* Plugin shows raw password in log when `java.net.URISyntaxException` is thrown
* Plugin try to retry ConfigException