### PR TITLE
Add `local_buffering` & `temp_file_threshold` configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 dist: precise
 language: java
 jdk:
-  - openjdk7
-  - oraclejdk7
+  - openjdk8
   - oraclejdk8
 script:
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: trusty
 language: java
 jdk:
   - openjdk8

--- a/build.gradle
+++ b/build.gradle
@@ -22,15 +22,15 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.+"
-    provided "org.embulk:embulk-core:0.8.+"
+    compile  "org.embulk:embulk-core:0.9.7"
+    provided "org.embulk:embulk-core:0.9.7"
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
     compile "org.apache.commons:commons-vfs2:2.2"
     compile "commons-io:commons-io:2.6"
     compile "com.jcraft:jsch:0.1.54"
     testCompile "junit:junit:4.+"
-    testCompile "org.embulk:embulk-core:0.8.+:tests"
-    testCompile "org.embulk:embulk-standards:0.8.+"
+    testCompile "org.embulk:embulk-core:0.9.7:tests"
+    testCompile "org.embulk:embulk-standards:0.9.7"
     testCompile "org.apache.sshd:apache-sshd:1.1.0+"
     testCompile "org.littleshoot:littleproxy:1.1.0-beta1"
     testCompile "io.netty:netty-all:4.0.34.Final"

--- a/build.gradle
+++ b/build.gradle
@@ -22,18 +22,19 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.6"
-    provided "org.embulk:embulk-core:0.8.6"
+    compile  "org.embulk:embulk-core:0.8.+"
+    provided "org.embulk:embulk-core:0.8.+"
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
     compile "org.apache.commons:commons-vfs2:2.2"
     compile "commons-io:commons-io:2.6"
     compile "com.jcraft:jsch:0.1.54"
     testCompile "junit:junit:4.+"
-    testCompile "org.embulk:embulk-core:0.8.6:tests"
-    testCompile "org.embulk:embulk-standards:0.8.6"
+    testCompile "org.embulk:embulk-core:0.8.+:tests"
+    testCompile "org.embulk:embulk-standards:0.8.+"
     testCompile "org.apache.sshd:apache-sshd:1.1.0+"
     testCompile "org.littleshoot:littleproxy:1.1.0-beta1"
     testCompile "io.netty:netty-all:4.0.34.Final"
+    testCompile "org.mockito:mockito-core:2.+"
 }
 
 jacocoTestReport {

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -15,6 +15,7 @@ import org.embulk.spi.unit.LocalFile;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -56,7 +56,7 @@ public class SftpFileOutputPlugin
         public int getSftpConnectionTimeout();
 
         @Config("max_connection_retry")
-        @ConfigDefault("7") // 7 times retry to connect sftp server if failed.
+        @ConfigDefault("5") // 5 times retry to connect sftp server if failed.
         public int getMaxConnectionRetry();
 
         @Config("path_prefix")

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -85,7 +85,7 @@ public class SftpFileOutputPlugin
         @Min(50L * 1024 * 1024) // 50MiB
         @Max(10L * 1024 * 1024 * 1024) // 10GiB
         @Config("temp_file_threshold")
-        @ConfigDefault("2147483648") // 2GiB
+        @ConfigDefault("5368709120") // 5GiB
         public long getTempFileThreshold();
     }
 

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -50,7 +50,7 @@ public class SftpFileOutputPlugin
 
         @Config("user_directory_is_root")
         @ConfigDefault("true")
-        public Boolean getUserDirIsRoot();
+        public boolean getUserDirIsRoot();
 
         @Config("timeout")
         @ConfigDefault("600") // 10 minutes
@@ -76,12 +76,12 @@ public class SftpFileOutputPlugin
 
         @Config("rename_file_after_upload")
         @ConfigDefault("false")
-        public Boolean getRenameFileAfterUpload();
+        public boolean getRenameFileAfterUpload();
 
         // if `false`, plugin will use remote file as buffer
         @Config("local_buffering")
         @ConfigDefault("true")
-        public Boolean getLocalBuffering();
+        public boolean getLocalBuffering();
 
         @Min(50L * 1024 * 1024) // 50MiB
         @Max(10L * 1024 * 1024 * 1024) // 10GiB

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -78,15 +78,15 @@ public class SftpFileOutputPlugin
         public Boolean getRenameFileAfterUpload();
 
         // if `false`, plugin will use remote file as buffer
-        @Config("local_buffer")
+        @Config("local_buffering")
         @ConfigDefault("true")
-        public Boolean getLocalBuffer();
+        public Boolean getLocalBuffering();
 
-        @Min(50 * 1024 * 1024) // 50MiB
+        @Min(50L * 1024 * 1024) // 50MiB
         @Max(10L * 1024 * 1024 * 1024) // 10GiB
-        @Config("local_buffer_size")
+        @Config("temp_file_threshold")
         @ConfigDefault("2147483648") // 2GiB
-        public long getLocalBufferSize();
+        public long getTempFileThreshold();
     }
 
     @Override
@@ -154,7 +154,7 @@ public class SftpFileOutputPlugin
     public TransactionalFileOutput open(TaskSource taskSource, final int taskIndex)
     {
         final PluginTask task = taskSource.loadTask(PluginTask.class);
-        if (task.getLocalBuffer()) {
+        if (task.getLocalBuffering()) {
             return new SftpLocalFileOutput(task, taskIndex);
         }
         return new SftpRemoteFileOutput(task, taskIndex);

--- a/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
@@ -170,12 +170,7 @@ public class SftpLocalFileOutput
     void closeRemoteFile()
     {
         if (remoteOutput != null) {
-            try (TimeoutCloser ignore = new TimeoutCloser(remoteOutput)) {
-                // do nothing, this is to pipe closing remoteFile after closing remoteOutput
-            }
-            finally {
-                new TimeoutCloser(remoteFile).close();
-            }
+            new TimeoutCloser(remoteOutput).close();
             remoteOutput = null;
             remoteFile = null;
             // if input config is not `renameFileAfterUpload`

--- a/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
@@ -126,6 +126,7 @@ public class SftpLocalFileOutput
     public void close()
     {
         closeCurrentFile();
+        closeRemoteFile();
         // TODO
         sftpUtils.close();
     }
@@ -169,12 +170,12 @@ public class SftpLocalFileOutput
             new TimeoutCloser(remoteFile).close();
             remoteFile = null;
             remoteOutput = null;
-        }
-        // if input config is not `renameFileAfterUpload`
-        // and file is being split, we have to rename it here
-        // otherwise, when it exits, it won't rename
-        if (!renameFileAfterUpload && appending) {
-            sftpUtils.renameFile(tempFilename, curFilename);
+            // if input config is not `renameFileAfterUpload`
+            // and file is being split, we have to rename it here
+            // otherwise, when it exits, it won't rename
+            if (!renameFileAfterUpload && appending) {
+                sftpUtils.renameFile(tempFilename, curFilename);
+            }
         }
     }
 

--- a/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
@@ -121,6 +121,12 @@ public class SftpLocalFileOutput
             throw Throwables.propagate(e);
         }
         closeRemoteFile();
+        // if input config is not `renameFileAfterUpload`
+        // and file is being split, we have to rename it here
+        // otherwise, when it exits, it won't rename
+        if (!renameFileAfterUpload && appending) {
+            sftpUtils.renameFile(tempFilename, curFilename);
+        }
         fileList.add(fileReport());
         fileIndex++;
     }
@@ -173,12 +179,6 @@ public class SftpLocalFileOutput
             new TimeoutCloser(remoteOutput).close();
             remoteOutput = null;
             remoteFile = null;
-            // if input config is not `renameFileAfterUpload`
-            // and file is being split, we have to rename it here
-            // otherwise, when it exits, it won't rename
-            if (!renameFileAfterUpload && appending) {
-                sftpUtils.renameFile(tempFilename, curFilename);
-            }
         }
     }
 

--- a/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
@@ -26,13 +26,18 @@ import static org.embulk.output.sftp.SftpFileOutputPlugin.PluginTask;
 public class SftpLocalFileOutput
         implements FileOutput, TransactionalFileOutput
 {
+    // to make it clear that it is a constant
+    static final String TMP_SUFFIX = ".tmp";
+
     final Logger logger = Exec.getLogger(getClass());
     private final String pathPrefix;
     private final String sequenceFormat;
     private final String fileNameExtension;
     private boolean renameFileAfterUpload;
     // flush will be triggered when local temp file reaches this threshold
-    private final long localBufferSize;
+    private final long threshold;
+    private boolean appending = false;
+    private long bufLen = 0L;
 
     private final int taskIndex;
     final SftpUtils sftpUtils;
@@ -40,8 +45,6 @@ public class SftpLocalFileOutput
     private File tempFile;
     BufferedOutputStream localOutput = null;
     List<Map<String, String>> fileList = new ArrayList<>();
-
-    final String temporaryFileSuffix = ".tmp";
 
     SftpLocalFileOutput(PluginTask task, int taskIndex)
     {
@@ -51,7 +54,7 @@ public class SftpLocalFileOutput
         this.renameFileAfterUpload = task.getRenameFileAfterUpload();
         this.taskIndex = taskIndex;
         this.sftpUtils = new SftpUtils(task);
-        this.localBufferSize = task.getLocalBufferSize();
+        this.threshold = task.getTempFileThreshold();
     }
 
     @Override
@@ -73,16 +76,21 @@ public class SftpLocalFileOutput
     public void add(final Buffer buffer)
     {
         try {
-            if (tempFile.length() + buffer.limit() > localBufferSize) {
+            final int len = buffer.limit();
+            if (bufLen + len > threshold) {
                 // if we have to split into multiple uploads (append mode)
-                // have to use `.tmp` filename and switch on `renameFileAfterUpload`
+                // we have to use `.tmp` filename (ie. turn on `renameFileAfterUpload`)
                 renameFileAfterUpload = true;
                 // ignore returned value, as we don't need the report here
                 flush();
+                // toggle `appending`
+                appending = true;
                 // reset output stream (overwrite local temp file)
                 localOutput = new BufferedOutputStream(new FileOutputStream(tempFile));
+                bufLen = 0L;
             }
-            localOutput.write(buffer.array(), buffer.offset(), buffer.limit());
+            localOutput.write(buffer.array(), buffer.offset(), len);
+            bufLen += len;
         }
         catch (IOException ex) {
             throw Throwables.propagate(ex);
@@ -96,7 +104,13 @@ public class SftpLocalFileOutput
     public void finish()
     {
         // collect report of last flush
-        fileList.add(flush());
+        try {
+            fileList.add(flush());
+        }
+        catch (IOException e) {
+            logger.error("Failed to (final) flush");
+            throw Throwables.propagate(e);
+        }
         fileIndex++;
     }
 
@@ -111,6 +125,15 @@ public class SftpLocalFileOutput
     @Override
     public void abort()
     {
+        // delete incomplete files
+        String fileName = getOutputFilePath();
+        String temporaryFileName = fileName + TMP_SUFFIX;
+        if (renameFileAfterUpload) {
+            sftpUtils.deleteFile(temporaryFileName);
+        }
+        else {
+            sftpUtils.deleteFile(fileName);
+        }
     }
 
     @Override
@@ -138,16 +161,16 @@ public class SftpLocalFileOutput
         return pathPrefix + String.format(sequenceFormat, taskIndex, fileIndex) + fileNameExtension;
     }
 
-    private Map<String, String> flush()
+    private Map<String, String> flush() throws IOException
     {
         closeCurrentFile();
         String fileName = getOutputFilePath();
-        String temporaryFileName = fileName + temporaryFileSuffix;
+        String temporaryFileName = fileName + TMP_SUFFIX;
         if (renameFileAfterUpload) {
-            sftpUtils.uploadFile(tempFile, temporaryFileName, true);
+            sftpUtils.uploadFile(tempFile, temporaryFileName, appending);
         }
         else {
-            sftpUtils.uploadFile(tempFile, fileName, false);
+            sftpUtils.uploadFile(tempFile, fileName, appending);
         }
         return fileReport(temporaryFileName, fileName);
     }

--- a/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
@@ -73,6 +73,7 @@ public class SftpLocalFileOutput
         try {
             tempFile = Exec.getTempFileSpace().createTempFile();
             localOutput = new BufferedOutputStream(new FileOutputStream(tempFile));
+            appending = false;
             curFilename = getOutputFilePath();
             tempFilename = curFilename + TMP_SUFFIX;
         }
@@ -203,12 +204,7 @@ public class SftpLocalFileOutput
             sftpUtils.appendFile(tempFile, remoteFile, remoteOutput);
         }
         else {
-            if (renameFileAfterUpload) {
-                sftpUtils.uploadFile(tempFile, tempFilename);
-            }
-            else {
-                sftpUtils.uploadFile(tempFile, curFilename);
-            }
+            sftpUtils.uploadFile(tempFile, renameFileAfterUpload ? tempFilename : curFilename);
         }
     }
 }

--- a/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpLocalFileOutput.java
@@ -135,7 +135,6 @@ public class SftpLocalFileOutput
     public void close()
     {
         closeCurrentFile();
-        closeRemoteFile();
         // TODO
         sftpUtils.close();
     }

--- a/src/main/java/org/embulk/output/sftp/SftpRemoteFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpRemoteFileOutput.java
@@ -23,7 +23,7 @@ public class SftpRemoteFileOutput extends SftpLocalFileOutput
         try {
             String fileName = getOutputFilePath();
             // always write to remote .tmp first
-            String temporaryFileName = fileName + temporaryFileSuffix;
+            String temporaryFileName = fileName + TMP_SUFFIX;
             // resolve remote file & open output stream
             FileObject tempFile = sftpUtils.newSftpFile(sftpUtils.getSftpFileUri(temporaryFileName));
             // this is where it's different from {@code SftpLocalFileOutput}
@@ -42,7 +42,7 @@ public class SftpRemoteFileOutput extends SftpLocalFileOutput
         // closing remote output stream is enough
         closeCurrentFile();
         String fileName = getOutputFilePath();
-        String temporaryFileName = fileName + temporaryFileSuffix;
+        String temporaryFileName = fileName + TMP_SUFFIX;
 
         fileList.add(fileReport(temporaryFileName, fileName));
         fileIndex++;

--- a/src/main/java/org/embulk/output/sftp/SftpRemoteFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpRemoteFileOutput.java
@@ -1,18 +1,80 @@
 package org.embulk.output.sftp;
 
 import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.Service;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
+import org.embulk.output.sftp.utils.TimedCallable;
+import org.embulk.spi.Buffer;
 
 import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.embulk.output.sftp.SftpFileOutputPlugin.PluginTask;
 
 public class SftpRemoteFileOutput extends SftpLocalFileOutput
 {
+    private static final int TIMEOUT = 60; // 1min
+    private Service watcher;
+
     SftpRemoteFileOutput(PluginTask task, int taskIndex)
     {
         super(task, taskIndex);
+    }
+
+    @Override
+    public void add(final Buffer buffer)
+    {
+        try {
+            final int len = buffer.limit();
+            // time-out write
+            new TimedCallable<Void>()
+            {
+                @Override
+                public Void call() throws Exception
+                {
+                    localOutput.write(buffer.array(), buffer.offset(), len);
+                    return null;
+                }
+            }.call(TIMEOUT, TimeUnit.SECONDS);
+            bufLen += len;
+        }
+        catch (InterruptedException | ExecutionException | TimeoutException ex) {
+            logger.error("Failed to write buffer", ex);
+            stopWatcher();
+            throw Throwables.propagate(ex);
+        }
+        finally {
+            buffer.release();
+        }
+    }
+
+    void closeCurrentFile()
+    {
+        if (localOutput != null) {
+            new TimedCallable<Void>()
+            {
+                @Override
+                public Void call() throws IOException
+                {
+                    localOutput.close();
+                    return null;
+                }
+            }.callNonInterruptible(TIMEOUT, TimeUnit.SECONDS);
+            localOutput = null;
+        }
+        stopWatcher();
+    }
+
+    void stopWatcher()
+    {
+        if (watcher != null) {
+            watcher.stopAsync();
+        }
     }
 
     @Override
@@ -26,11 +88,13 @@ public class SftpRemoteFileOutput extends SftpLocalFileOutput
             String temporaryFileName = fileName + TMP_SUFFIX;
             // resolve remote file & open output stream
             FileObject tempFile = sftpUtils.newSftpFile(sftpUtils.getSftpFileUri(temporaryFileName));
-            // this is where it's different from {@code SftpLocalFileOutput}
+            // this is where it's different from |SftpLocalFileOutput|
             // localOutput is now an OutputStream of remote file
             localOutput = new BufferedOutputStream(tempFile.getContent().getOutputStream());
+            watcher = newProgressWatcher().startAsync();
         }
         catch (FileSystemException e) {
+            stopWatcher();
             logger.error(e.getMessage());
             throw Throwables.propagate(e);
         }
@@ -39,12 +103,34 @@ public class SftpRemoteFileOutput extends SftpLocalFileOutput
     @Override
     public void finish()
     {
-        // closing remote output stream is enough
         closeCurrentFile();
         String fileName = getOutputFilePath();
         String temporaryFileName = fileName + TMP_SUFFIX;
-
+        sftpUtils.renameFile(temporaryFileName, fileName);
         fileList.add(fileReport(temporaryFileName, fileName));
         fileIndex++;
+        stopWatcher();
+    }
+
+    private Service newProgressWatcher()
+    {
+        return new AbstractScheduledService()
+        {
+            private static final int PERIOD = 10; // seconds
+            private long prevLen = 0L;
+
+            @Override
+            protected void runOneIteration()
+            {
+                logger.info("Upload progress: {} KB - {} KB/s", bufLen / 1024, (bufLen - prevLen) / 1024 / PERIOD);
+                prevLen = bufLen;
+            }
+
+            @Override
+            protected Scheduler scheduler()
+            {
+                return Scheduler.newFixedRateSchedule(PERIOD, PERIOD, TimeUnit.SECONDS);
+            }
+        };
     }
 }

--- a/src/main/java/org/embulk/output/sftp/SftpRemoteFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpRemoteFileOutput.java
@@ -1,0 +1,50 @@
+package org.embulk.output.sftp;
+
+import com.google.common.base.Throwables;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+
+import java.io.BufferedOutputStream;
+
+import static org.embulk.output.sftp.SftpFileOutputPlugin.PluginTask;
+
+public class SftpRemoteFileOutput extends SftpLocalFileOutput
+{
+    SftpRemoteFileOutput(PluginTask task, int taskIndex)
+    {
+        super(task, taskIndex);
+    }
+
+    @Override
+    public void nextFile()
+    {
+        closeCurrentFile();
+
+        try {
+            String fileName = getOutputFilePath();
+            // always write to remote .tmp first
+            String temporaryFileName = fileName + temporaryFileSuffix;
+            // resolve remote file & open output stream
+            FileObject tempFile = sftpUtils.newSftpFile(sftpUtils.getSftpFileUri(temporaryFileName));
+            // this is where it's different from {@code SftpLocalFileOutput}
+            // localOutput is now an OutputStream of remote file
+            localOutput = new BufferedOutputStream(tempFile.getContent().getOutputStream());
+        }
+        catch (FileSystemException e) {
+            logger.error(e.getMessage());
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public void finish()
+    {
+        // closing remote output stream is enough
+        closeCurrentFile();
+        String fileName = getOutputFilePath();
+        String temporaryFileName = fileName + temporaryFileSuffix;
+
+        fileList.add(fileReport(temporaryFileName, fileName));
+        fileIndex++;
+    }
+}

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -19,7 +19,6 @@ import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
 import org.embulk.spi.util.RetryExecutor.Retryable;
 import org.slf4j.Logger;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -188,7 +187,7 @@ public class SftpUtils
         long startTime = System.nanoTime();
 
         // start uploading
-        try (final BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(localTempFile))) {
+        try (InputStream inputStream = new FileInputStream(localTempFile)) {
             logger.info("Uploading to remote sftp file ({} KB): {}", size / 1024, remoteFile.getPublicURIString());
             final byte[] buffer = new byte[32 * 1024 * 1024]; // 32MB buffer size
             int len = inputStream.read(buffer);

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -18,6 +18,7 @@ import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
 import org.embulk.spi.util.RetryExecutor.Retryable;
 import org.slf4j.Logger;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -259,16 +260,16 @@ public class SftpUtils
         });
     }
 
-    OutputStream openStream(final FileObject remoteFile)
+    BufferedOutputStream openStream(final FileObject remoteFile)
     {
         // output stream is already a BufferedOutputStream, no need to wrap
         final String taskName = "SFTP open stream";
-        return withRetry(new DefaultRetry<OutputStream>(taskName)
+        return withRetry(new DefaultRetry<BufferedOutputStream>(taskName)
         {
             @Override
-            public OutputStream call() throws Exception
+            public BufferedOutputStream call() throws Exception
             {
-                return remoteFile.getContent().getOutputStream();
+                return new BufferedOutputStream(remoteFile.getContent().getOutputStream());
             }
         });
     }

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -253,17 +253,9 @@ public class SftpUtils
         }
     }
 
-    FileObject resolve(final String remoteFilePath)
+    FileObject resolve(final String remoteFilePath) throws FileSystemException
     {
-        final String taskName = String.format("SFTP resolve file '%s'", remoteFilePath);
-        return withRetry(new DefaultRetry<FileObject>(taskName)
-        {
-            @Override
-            public FileObject call() throws Exception
-            {
-                return manager.resolveFile(getSftpFileUri(remoteFilePath).toString(), fsOptions);
-            }
-        });
+        return manager.resolveFile(getSftpFileUri(remoteFilePath).toString(), fsOptions);
     }
 
     BufferedOutputStream openStream(final FileObject remoteFile)

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -16,12 +16,21 @@ import org.embulk.spi.util.RetryExecutor.Retryable;
 import org.slf4j.Logger;
 
 import java.io.BufferedOutputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 
 import static org.embulk.output.sftp.SftpFileOutputPlugin.PluginTask;
@@ -32,8 +41,10 @@ import static org.embulk.spi.util.RetryExecutor.retryExecutor;
  */
 public class SftpUtils
 {
+    private static final ExecutorService THREAD_POOL = Executors.newCachedThreadPool();
+
     private final Logger logger = Exec.getLogger(SftpUtils.class);
-    private final DefaultFileSystemManager manager;
+    private DefaultFileSystemManager manager;
     private final FileSystemOptions fsOptions;
     private final String userInfo;
     private final String user;
@@ -53,7 +64,7 @@ public class SftpUtils
          * https://github.com/embulk/embulk-output-sftp/issues/40
          * https://github.com/embulk/embulk-output-sftp/pull/44
          * https://issues.apache.org/jira/browse/VFS-590
-        */
+         */
         DefaultFileSystemManager manager = new DefaultFileSystemManager();
         try {
             manager.addProvider("sftp", new org.embulk.output.sftp.provider.sftp.SftpFileProvider());
@@ -87,8 +98,8 @@ public class SftpUtils
             builder.setStrictHostKeyChecking(fsOptions, "no");
             if (task.getSecretKeyFilePath().isPresent()) {
                 IdentityInfo identityInfo = new IdentityInfo(
-                    new File((task.getSecretKeyFilePath().transform(localFileToPathString()).get())),
-                    task.getSecretKeyPassphrase().getBytes()
+                        new File((task.getSecretKeyFilePath().transform(localFileToPathString()).get())),
+                        task.getSecretKeyPassphrase().getBytes()
                 );
                 builder.setIdentityInfo(fsOptions, identityInfo);
                 logger.info("set identity: {}", task.getSecretKeyFilePath().get());
@@ -141,14 +152,20 @@ public class SftpUtils
         manager.close();
     }
 
-    public Void uploadFile(final File localTempFile, final String remotePath)
+    public void uploadFile(final File localTempFile, final String remotePath)
+    {
+        uploadFile(localTempFile, remotePath, false);
+    }
+
+    Void uploadFile(final File localTempFile, final String remotePath, final boolean append)
     {
         try {
             return retryExecutor()
                     .withRetryLimit(maxConnectionRetry)
-                    .withInitialRetryWait(500)
-                    .withMaxRetryWait(30 * 1000)
-                    .runInterruptible(new Retryable<Void>() {
+                    .withInitialRetryWait(120 * 1000)
+                    .withMaxRetryWait(3600 * 1000)
+                    .runInterruptible(new Retryable<Void>()
+                    {
                         @Override
                         public Void call() throws IOException
                         {
@@ -157,17 +174,17 @@ public class SftpUtils
                             long bytesPerStep = size / step;
                             long startTime = System.nanoTime();
 
-                            try (FileObject remoteFile = newSftpFile(getSftpFileUri(remotePath));
-                                    InputStream inputStream = new FileInputStream(localTempFile);
-                                    BufferedOutputStream outputStream = new BufferedOutputStream(remoteFile.getContent().getOutputStream());
-                            ) {
+                            final FileObject remoteFile = newSftpFile(getSftpFileUri(remotePath));
+                            // output stream is already a BufferedOutputStream, no need to wrap
+                            final OutputStream outputStream = remoteFile.getContent().getOutputStream(append);
+                            try (InputStream inputStream = new FileInputStream(localTempFile)) {
                                 logger.info("Uploading to remote sftp file ({} KB): {}", size / 1024, remoteFile.getPublicURIString());
-                                byte[] buffer = new byte[32 * 1024 * 1024]; // 32MB buffer size
+                                final byte[] buffer = new byte[32 * 1024 * 1024]; // 32MB buffer size
                                 int len = inputStream.read(buffer);
                                 long total = 0;
                                 int progress = 0;
                                 while (len != -1) {
-                                    outputStream.write(buffer, 0, len);
+                                    timedWrite(outputStream, buffer, len);
                                     len = inputStream.read(buffer);
                                     total += len;
                                     if (total / bytesPerStep > progress) {
@@ -178,6 +195,13 @@ public class SftpUtils
                                     }
                                 }
                                 logger.info("Upload completed.");
+                            }
+                            catch (Exception e) {
+                                // why not try-with-resource?
+                                // because it will hang trying to flush/close resource when TimeoutException
+                                timedClose(outputStream);
+                                timedClose(remoteFile);
+                                throw e;
                             }
                             return null;
                         }
@@ -202,6 +226,10 @@ public class SftpUtils
                             else {
                                 logger.warn(message);
                             }
+                            logger.info("Re-initializing FileSystemManager ... ");
+                            manager.close();
+                            manager = initializeStandardFileSystemManager();
+                            logger.info("Re-initializing FileSystemManager completed.");
                         }
 
                         @Override
@@ -225,7 +253,8 @@ public class SftpUtils
                     .withRetryLimit(maxConnectionRetry)
                     .withInitialRetryWait(500)
                     .withMaxRetryWait(30 * 1000)
-                    .runInterruptible(new Retryable<Void>() {
+                    .runInterruptible(new Retryable<Void>()
+                    {
                         @Override
                         public Void call() throws IOException
                         {
@@ -285,7 +314,7 @@ public class SftpUtils
         }
     }
 
-    private URI getSftpFileUri(String remoteFilePath)
+    URI getSftpFileUri(String remoteFilePath)
     {
         try {
             return new URI("sftp", userInfo, host, port, remoteFilePath, null, null);
@@ -296,7 +325,7 @@ public class SftpUtils
         }
     }
 
-    private FileObject newSftpFile(final URI sftpUri) throws FileSystemException
+    FileObject newSftpFile(final URI sftpUri) throws FileSystemException
     {
         FileObject file = manager.resolveFile(sftpUri.toString(), fsOptions);
         if (file.exists()) {
@@ -321,5 +350,63 @@ public class SftpUtils
                 return file.getPath().toString();
             }
         };
+    }
+
+    private void timedWrite(final OutputStream stream, final byte[] buf, final int len) throws IOException
+    {
+        FutureTask<Integer> task = new FutureTask<>(new Callable<Integer>()
+        {
+            public Integer call() throws Exception
+            {
+                if (Thread.interrupted()) {
+                    // this is not actual exit code
+                    // we inverse exit code because initial value of int is 0
+                    return 0;
+                }
+                stream.write(buf, 0, len);
+                return 1;
+            }
+        });
+        try {
+            int returnCode = timedCall(task, 120, TimeUnit.SECONDS);
+            if (returnCode != 1) {
+                throw new IOException("Buffer couldn't be uploaded properly, retry from beginning");
+            }
+        }
+        catch (Exception e) {
+            logger.warn("Failed to write buffer, retrying ...");
+            task.cancel(true);
+            throw new IOException(e);
+        }
+    }
+
+    private void timedClose(final Closeable resource)
+    {
+        try {
+            timedCall(new FutureTask<>(new Callable<Void>()
+            {
+                @Override
+                public Void call() throws Exception
+                {
+                    if (resource != null) {
+                        resource.close();
+                    }
+                    return null;
+                }
+            }), 60, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException | ExecutionException e) {
+            logger.warn("Failed to close resource: {}", e.getMessage());
+        }
+        catch (TimeoutException e) {
+            logger.info("Timed out while closing resource");
+        }
+    }
+
+    private static <T> T timedCall(FutureTask<T> task, long timeout, TimeUnit timeUnit)
+            throws InterruptedException, ExecutionException, TimeoutException
+    {
+        THREAD_POOL.execute(task);
+        return task.get(timeout, timeUnit);
     }
 }

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -165,7 +165,7 @@ public class SftpUtils
     }
 
     /**
-     * This method won't close outputStream, outputStream is intended to be reused
+     * This method won't close outputStream, outputStream is intended to keep open for next write
      *
      * @param localTempFile
      * @param remoteFile

--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -157,7 +157,7 @@ public class SftpUtils
                 final OutputStream outputStream = openStream(remoteFile);
                 // When channel is broken, closing resource may hang, hence the time-out wrapper
                 // Note: closing FileObject will also close OutputStream
-                try (TimeoutCloser ignored = new TimeoutCloser(remoteFile)) {
+                try (TimeoutCloser ignored = new TimeoutCloser(outputStream)) {
                     appendFile(localTempFile, remoteFile, outputStream);
                     return null;
                 }

--- a/src/main/java/org/embulk/output/sftp/utils/DefaultRetry.java
+++ b/src/main/java/org/embulk/output/sftp/utils/DefaultRetry.java
@@ -1,0 +1,41 @@
+package org.embulk.output.sftp.utils;
+
+import org.embulk.spi.Exec;
+import org.embulk.spi.util.RetryExecutor;
+import org.slf4j.Logger;
+
+public abstract class DefaultRetry<T> implements RetryExecutor.Retryable<T>
+{
+    private Logger logger = Exec.getLogger(getClass());
+
+    private final String task;
+
+    protected DefaultRetry(String task)
+    {
+        this.task = task;
+    }
+
+    @Override
+    public boolean isRetryableException(Exception exception)
+    {
+        return true;
+    }
+
+    @Override
+    public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
+    {
+        String message = String.format("%s failed. Retrying %d/%d after %d seconds. Message: %s",
+                task, retryCount, retryLimit, retryWait / 1000, exception.getMessage());
+        if (retryCount % 3 == 0) {
+            logger.warn(message, exception);
+        }
+        else {
+            logger.warn(message);
+        }
+    }
+
+    @Override
+    public void onGiveup(Exception firstException, Exception lastException)
+    {
+    }
+}

--- a/src/main/java/org/embulk/output/sftp/utils/TimedCallable.java
+++ b/src/main/java/org/embulk/output/sftp/utils/TimedCallable.java
@@ -1,6 +1,5 @@
 package org.embulk.output.sftp.utils;
 
-import com.google.common.base.Optional;
 import org.embulk.spi.Exec;
 import org.slf4j.Logger;
 
@@ -23,7 +22,7 @@ public abstract class TimedCallable<V> implements Callable<V>
             return call(timeout, timeUnit);
         }
         catch (Exception e) {
-            logger.warn("Failed with exception {}: {}", e.getClass(), Optional.fromNullable(e.getMessage()).or(""));
+            logger.warn("Time-out call failed, ignore and resume", e);
             return null;
         }
     }
@@ -36,10 +35,8 @@ public abstract class TimedCallable<V> implements Callable<V>
             THREAD_POOL.execute(task);
             return task.get(timeout, timeUnit);
         }
-        catch (TimeoutException e) {
-            logger.warn("Execution timed out, re-throwing ...");
+        finally {
             task.cancel(true);
-            throw e;
         }
     }
 }

--- a/src/main/java/org/embulk/output/sftp/utils/TimedCallable.java
+++ b/src/main/java/org/embulk/output/sftp/utils/TimedCallable.java
@@ -1,8 +1,5 @@
 package org.embulk.output.sftp.utils;
 
-import org.embulk.spi.Exec;
-import org.slf4j.Logger;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -14,18 +11,6 @@ import java.util.concurrent.TimeoutException;
 public abstract class TimedCallable<V> implements Callable<V>
 {
     private static final ExecutorService THREAD_POOL = Executors.newCachedThreadPool();
-    private Logger logger = Exec.getLogger(getClass());
-
-    public V callNonInterruptible(long timeout, TimeUnit timeUnit)
-    {
-        try {
-            return call(timeout, timeUnit);
-        }
-        catch (Exception e) {
-            logger.warn("Time-out call failed, ignore and resume", e);
-            return null;
-        }
-    }
 
     public V call(long timeout, TimeUnit timeUnit)
             throws InterruptedException, ExecutionException, TimeoutException

--- a/src/main/java/org/embulk/output/sftp/utils/TimedCallable.java
+++ b/src/main/java/org/embulk/output/sftp/utils/TimedCallable.java
@@ -1,0 +1,45 @@
+package org.embulk.output.sftp.utils;
+
+import com.google.common.base.Optional;
+import org.embulk.spi.Exec;
+import org.slf4j.Logger;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public abstract class TimedCallable<V> implements Callable<V>
+{
+    private static final ExecutorService THREAD_POOL = Executors.newCachedThreadPool();
+    private Logger logger = Exec.getLogger(getClass());
+
+    public V callNonInterruptible(long timeout, TimeUnit timeUnit)
+    {
+        try {
+            return call(timeout, timeUnit);
+        }
+        catch (Exception e) {
+            logger.warn("Failed with exception {}: {}", e.getClass(), Optional.fromNullable(e.getMessage()).or(""));
+            return null;
+        }
+    }
+
+    public V call(long timeout, TimeUnit timeUnit)
+            throws InterruptedException, ExecutionException, TimeoutException
+    {
+        FutureTask<V> task = new FutureTask<>(this);
+        try {
+            THREAD_POOL.execute(task);
+            return task.get(timeout, timeUnit);
+        }
+        catch (TimeoutException e) {
+            logger.warn("Execution timed out, re-throwing ...");
+            task.cancel(true);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/org/embulk/output/sftp/utils/TimeoutCloser.java
+++ b/src/main/java/org/embulk/output/sftp/utils/TimeoutCloser.java
@@ -1,0 +1,30 @@
+package org.embulk.output.sftp.utils;
+
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+
+public class TimeoutCloser implements Closeable
+{
+    private Closeable wrapped;
+
+    public TimeoutCloser(Closeable wrapped)
+    {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public void close()
+    {
+        new TimedCallable<Void>()
+        {
+            @Override
+            public Void call() throws Exception
+            {
+                if (wrapped != null) {
+                    wrapped.close();
+                }
+                return null;
+            }
+        }.callNonInterruptible(60, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/org/embulk/output/sftp/utils/TimeoutCloser.java
+++ b/src/main/java/org/embulk/output/sftp/utils/TimeoutCloser.java
@@ -25,6 +25,6 @@ public class TimeoutCloser implements Closeable
                 }
                 return null;
             }
-        }.callNonInterruptible(60, TimeUnit.SECONDS);
+        }.callNonInterruptible(120, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/org/embulk/output/sftp/utils/TimeoutCloser.java
+++ b/src/main/java/org/embulk/output/sftp/utils/TimeoutCloser.java
@@ -1,10 +1,14 @@
 package org.embulk.output.sftp.utils;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.Closeable;
 import java.util.concurrent.TimeUnit;
 
 public class TimeoutCloser implements Closeable
 {
+    @VisibleForTesting
+    int timeout = 120;
     private Closeable wrapped;
 
     public TimeoutCloser(Closeable wrapped)
@@ -25,6 +29,6 @@ public class TimeoutCloser implements Closeable
                 }
                 return null;
             }
-        }.callNonInterruptible(120, TimeUnit.SECONDS);
+        }.callNonInterruptible(timeout, TimeUnit.SECONDS);
     }
 }

--- a/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertThat;
 import static org.msgpack.value.ValueFactory.newMap;
 import static org.msgpack.value.ValueFactory.newString;
 
-public class TestSftpLocalFileOutputPlugin
+public class TestSftpFileOutputPlugin
 {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
@@ -74,7 +74,7 @@ public class TestSftpLocalFileOutputPlugin
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
-    private Logger logger = runtime.getExec().getLogger(TestSftpLocalFileOutputPlugin.class);
+    private Logger logger = runtime.getExec().getLogger(TestSftpFileOutputPlugin.class);
     private FileOutputRunner runner;
     private SshServer sshServer;
     private static final String HOST = "127.0.0.1";

--- a/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
@@ -747,7 +747,7 @@ public class TestSftpFileOutputPlugin
     }
 
     @Test
-    public void testResolveWithRetry()
+    public void testResolveWithoutRetry()
     {
         SftpFileOutputPlugin.PluginTask task = defaultTask();
         SftpUtils utils = Mockito.spy(new SftpUtils(task));
@@ -756,10 +756,15 @@ public class TestSftpFileOutputPlugin
                 .doCallRealMethod()
                 .when(utils).getSftpFileUri(Mockito.eq(defaultPathPrefix));
 
-        utils.resolve(defaultPathPrefix);
-
-        // assert retry
-        Mockito.verify(utils, Mockito.times(2)).getSftpFileUri(Mockito.eq(defaultPathPrefix));
+        try {
+            utils.resolve(defaultPathPrefix);
+            fail("Should not reach here");
+        }
+        catch (Exception e) {
+            assertThat(e, CoreMatchers.<Exception>instanceOf(ConfigException.class));
+            // assert retry
+            Mockito.verify(utils, Mockito.times(1)).getSftpFileUri(Mockito.eq(defaultPathPrefix));
+        }
     }
 
     @Test

--- a/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
@@ -4,6 +4,9 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
+import com.jcraft.jsch.JSchException;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
 import org.apache.sshd.server.Command;
@@ -29,7 +32,9 @@ import org.embulk.spi.PageTestUtils;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
 import org.embulk.spi.time.Timestamp;
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,17 +42,28 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.PublicKey;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeoutException;
 
 import static com.google.common.io.Files.readLines;
 import static org.embulk.spi.type.Types.BOOLEAN;
@@ -58,8 +74,14 @@ import static org.embulk.spi.type.Types.STRING;
 import static org.embulk.spi.type.Types.TIMESTAMP;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.msgpack.value.ValueFactory.newMap;
 import static org.msgpack.value.ValueFactory.newString;
 
@@ -93,6 +115,8 @@ public class TestSftpFileOutputPlugin
             .add("_c4", TIMESTAMP)
             .add("_c5", JSON)
             .build();
+
+    private final String defaultPathPrefix = "/test/testUserPassword";
 
     @Before
     public void createResources()
@@ -201,8 +225,8 @@ public class TestSftpFileOutputPlugin
                     // true,2,3.0,45,1970-01-01 00:00:00.678000 +0000,{\"k\":\"v\"}
                     // true,2,3.0,45,1970-01-01 00:00:00.678000 +0000,{\"k\":\"v\"}
                     for (Page page : PageTestUtils.buildPage(runtime.getBufferAllocator(), SCHEMA,
-                                 true, 2L, 3.0D, "45", Timestamp.ofEpochMilli(678L), newMap(newString("k"), newString("v")),
-                                 true, 2L, 3.0D, "45", Timestamp.ofEpochMilli(678L), newMap(newString("k"), newString("v")))) {
+                            true, 2L, 3.0D, "45", Timestamp.ofEpochMilli(678L), newMap(newString("k"), newString("v")),
+                            true, 2L, 3.0D, "45", Timestamp.ofEpochMilli(678L), newMap(newString("k"), newString("v")))) {
                         pageOutput.add(page);
                     }
                     pageOutput.commit();
@@ -223,7 +247,7 @@ public class TestSftpFileOutputPlugin
     {
         try {
             List<String> lines = readLines(new File(filePath),
-                                           Charsets.UTF_8);
+                    Charsets.UTF_8);
             for (int i = 0; i < lines.size(); i++) {
                 String[] record = lines.get(i).split(",");
                 if (i == 0) {
@@ -402,8 +426,8 @@ public class TestSftpFileOutputPlugin
         List<String> fileList = lsR(Lists.<String>newArrayList(), Paths.get(testFolder.getRoot().getAbsolutePath()));
         assertThat(fileList, hasItem(containsString(pathPrefix + "001.00.txt")));
         assertRecordsInFile(String.format("%s/%s001.00.txt",
-                                          testFolder.getRoot().getAbsolutePath(),
-                                          pathPrefix));
+                testFolder.getRoot().getAbsolutePath(),
+                pathPrefix));
     }
 
     @Test
@@ -439,8 +463,8 @@ public class TestSftpFileOutputPlugin
         assertThat(fileList, hasItem(containsString(pathPrefix + "001.00.txt")));
 
         assertRecordsInFile(String.format("%s/%s001.00.txt",
-                                          testFolder.getRoot().getAbsolutePath(),
-                                          pathPrefix));
+                testFolder.getRoot().getAbsolutePath(),
+                pathPrefix));
     }
 
     @Test
@@ -448,7 +472,7 @@ public class TestSftpFileOutputPlugin
     {
         HttpProxyServer proxyServer = null;
         try {
-             proxyServer = createProxyServer(PROXY_PORT);
+            proxyServer = createProxyServer(PROXY_PORT);
 
             // setting embulk config
             final String pathPrefix = "/test/testUserPassword";
@@ -521,5 +545,367 @@ public class TestSftpFileOutputPlugin
         catch (Exception e) {
             assertEquals(ConfigException.class, e.getClass());
         }
+    }
+
+    @Test
+    public void testUploadFileWithRetry() throws IOException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = Mockito.spy(new SftpUtils(task));
+
+        // append throws exception
+        Mockito.doThrow(new IOException("Fake Exception"))
+                .doCallRealMethod()
+                .when(utils)
+                .appendFile(Mockito.any(File.class), Mockito.any(FileObject.class), Mockito.any(OutputStream.class));
+
+        byte[] expected = randBytes(8);
+        File input = writeBytesToInputFile(expected);
+        utils.uploadFile(input, defaultPathPrefix);
+
+        // assert retry and recover
+        Mockito.verify(utils, Mockito.times(2)).appendFile(Mockito.any(File.class), Mockito.any(FileObject.class), Mockito.any(OutputStream.class));
+        List<String> fileList = lsR(Lists.<String>newArrayList(), Paths.get(testFolder.getRoot().getAbsolutePath()));
+        assertThat(fileList, hasItem(containsString(defaultPathPrefix)));
+
+        // assert uploaded file
+        String filePath = testFolder.getRoot().getAbsolutePath() + File.separator + defaultPathPrefix;
+        File output = new File(filePath);
+        InputStream in = new FileInputStream(output);
+        byte[] actual = new byte[8];
+        in.read(actual);
+        in.close();
+        Assert.assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testUploadFileRetryAndGiveUp() throws IOException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = Mockito.spy(new SftpUtils(task));
+
+        // append throws exception
+        Mockito.doThrow(new IOException("Fake IOException"))
+                .when(utils)
+                .appendFile(Mockito.any(File.class), Mockito.any(FileObject.class), Mockito.any(OutputStream.class));
+
+        byte[] expected = randBytes(8);
+        File input = writeBytesToInputFile(expected);
+        try {
+            utils.uploadFile(input, defaultPathPrefix);
+            fail("Should not reach here");
+        }
+        catch (Exception e) {
+            assertThat(e, CoreMatchers.<Exception>instanceOf(RuntimeException.class));
+            assertThat(e.getCause(), CoreMatchers.<Throwable>instanceOf(IOException.class));
+            assertEquals(e.getCause().getMessage(), "Fake IOException");
+            // assert used up all retries
+            Mockito.verify(utils, Mockito.times(task.getMaxConnectionRetry() + 1)).appendFile(Mockito.any(File.class), Mockito.any(FileObject.class), Mockito.any(OutputStream.class));
+            assertEmptyUploadedFile(defaultPathPrefix);
+        }
+    }
+
+    @Test
+    public void testUploadFileNotRetryAuthFail() throws IOException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = Mockito.spy(new SftpUtils(task));
+
+        // append throws exception
+        Mockito.doThrow(new IOException(new JSchException("USERAUTH fail")))
+                .doCallRealMethod()
+                .when(utils)
+                .appendFile(Mockito.any(File.class), Mockito.any(FileObject.class), Mockito.any(OutputStream.class));
+
+        byte[] expected = randBytes(8);
+        File input = writeBytesToInputFile(expected);
+        try {
+            utils.uploadFile(input, defaultPathPrefix);
+            fail("Should not reach here");
+        }
+        catch (Exception e) {
+            assertThat(e, CoreMatchers.<Exception>instanceOf(RuntimeException.class));
+            assertThat(e.getCause(), CoreMatchers.<Throwable>instanceOf(IOException.class));
+            assertThat(e.getCause().getCause(), CoreMatchers.<Throwable>instanceOf(JSchException.class));
+            assertEquals(e.getCause().getCause().getMessage(), "USERAUTH fail");
+            // assert no retry
+            Mockito.verify(utils, Mockito.times(1)).appendFile(Mockito.any(File.class), Mockito.any(FileObject.class), Mockito.any(OutputStream.class));
+            assertEmptyUploadedFile(defaultPathPrefix);
+        }
+    }
+
+    @Test
+    public void testAppendFile() throws IOException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = new SftpUtils(task);
+
+        FileObject remoteFile = utils.resolve(defaultPathPrefix);
+        OutputStream remoteOutput = utils.openStream(remoteFile);
+        // 1st append
+        byte[] expected = randBytes(16);
+        utils.appendFile(writeBytesToInputFile(Arrays.copyOfRange(expected, 0, 8)), remoteFile, remoteOutput);
+        // 2nd append
+        utils.appendFile(writeBytesToInputFile(Arrays.copyOfRange(expected, 8, 16)), remoteFile, remoteOutput);
+        remoteOutput.close();
+        remoteFile.close();
+
+        // assert uploaded file
+        String filePath = testFolder.getRoot().getAbsolutePath() + File.separator + defaultPathPrefix;
+        File output = new File(filePath);
+        InputStream in = new FileInputStream(output);
+        byte[] actual = new byte[16];
+        in.read(actual);
+        in.close();
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testAppendFileAndTimeOut() throws IOException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = new SftpUtils(task);
+        utils.writeTimeout = 1; // 1s time-out
+
+        byte[] expected = randBytes(8);
+        FileObject remoteFile = utils.resolve(defaultPathPrefix);
+        OutputStream remoteOutput = Mockito.spy(utils.openStream(remoteFile));
+
+        Mockito.doAnswer(new Answer()
+        {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable
+            {
+                Thread.sleep(2000); // 2s
+                return null;
+            }
+        }).when(remoteOutput).write(Mockito.any(byte[].class), Mockito.eq(0), Mockito.eq(8));
+
+        try {
+            utils.appendFile(writeBytesToInputFile(expected), remoteFile, remoteOutput);
+            fail("Should not reach here");
+        }
+        catch (IOException e) {
+            assertThat(e.getCause(), CoreMatchers.<Throwable>instanceOf(TimeoutException.class));
+            assertNull(e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void testRenameFileWithRetry() throws IOException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = Mockito.spy(new SftpUtils(task));
+
+        byte[] expected = randBytes(8);
+        File input = writeBytesToInputFile(expected);
+        utils.uploadFile(input, defaultPathPrefix);
+
+        Mockito.doThrow(new RuntimeException("Fake Exception"))
+                .doCallRealMethod()
+                .when(utils).resolve(Mockito.eq(defaultPathPrefix));
+
+        utils.renameFile(defaultPathPrefix, "/after");
+        Mockito.verify(utils, Mockito.times(1 + 2)).resolve(Mockito.any(String.class)); // 1 fail + 2 success
+
+        // assert renamed file
+        String filePath = testFolder.getRoot().getAbsolutePath() + "/after";
+        File output = new File(filePath);
+        InputStream in = new FileInputStream(output);
+        byte[] actual = new byte[8];
+        in.read(actual);
+        in.close();
+        Assert.assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testDeleteFile() throws IOException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = new SftpUtils(task);
+
+        // upload file
+        byte[] expected = randBytes(8);
+        File input = writeBytesToInputFile(expected);
+        utils.uploadFile(input, defaultPathPrefix);
+
+        FileObject target = utils.resolve(defaultPathPrefix);
+        assertTrue("File should exists", target.exists());
+
+        utils.deleteFile(defaultPathPrefix);
+
+        target = utils.resolve(defaultPathPrefix);
+        assertFalse("File should be deleted", target.exists());
+    }
+
+    @Test
+    public void testDeleteFileNotExists()
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = new SftpUtils(task);
+        utils.deleteFile("/not/exists");
+    }
+
+    @Test
+    public void testResolveWithRetry()
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = Mockito.spy(new SftpUtils(task));
+
+        Mockito.doThrow(new ConfigException("Fake ConfigException"))
+                .doCallRealMethod()
+                .when(utils).getSftpFileUri(Mockito.eq(defaultPathPrefix));
+
+        utils.resolve(defaultPathPrefix);
+
+        // assert retry
+        Mockito.verify(utils, Mockito.times(2)).getSftpFileUri(Mockito.eq(defaultPathPrefix));
+    }
+
+    @Test
+    public void testResolveRetryAndGiveUp()
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = Mockito.spy(new SftpUtils(task));
+
+        Mockito.doThrow(new ConfigException("Fake ConfigException"))
+                .when(utils).getSftpFileUri(Mockito.eq(defaultPathPrefix));
+
+        try {
+            utils.resolve(defaultPathPrefix);
+            fail("Should not reach here");
+        }
+        catch (Exception e) {
+            assertThat(e, CoreMatchers.<Exception>instanceOf(ConfigException.class));
+            assertEquals("Fake ConfigException", e.getMessage());
+
+            // assert retry
+            Mockito.verify(utils, Mockito.times(task.getMaxConnectionRetry() + 1)).getSftpFileUri(Mockito.eq(defaultPathPrefix));
+        }
+    }
+
+    @Test
+    public void testOpenStreamWithRetry() throws FileSystemException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = new SftpUtils(task);
+
+        FileObject mock = Mockito.spy(utils.resolve(defaultPathPrefix));
+        Mockito.doThrow(new FileSystemException("Fake FileSystemException"))
+                .doCallRealMethod()
+                .when(mock).getContent();
+
+        OutputStream stream = utils.openStream(mock);
+        assertNotNull(stream);
+        Mockito.verify(mock, Mockito.times(2)).getContent();
+    }
+
+    @Test
+    public void testNewSftpFileExists() throws IOException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = new SftpUtils(task);
+
+        byte[] expected = randBytes(8);
+        File input = writeBytesToInputFile(expected);
+        utils.uploadFile(input, defaultPathPrefix);
+
+        FileObject file = utils.resolve(defaultPathPrefix);
+        assertTrue("File should exists", file.exists());
+
+        file = utils.newSftpFile(utils.getSftpFileUri(defaultPathPrefix));
+        assertFalse("File should be deleted", file.exists());
+    }
+
+    @Test
+    public void testNewSftpFileParentNotExists() throws FileSystemException
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+        SftpUtils utils = new SftpUtils(task);
+
+        String parentPath = defaultPathPrefix.substring(0, defaultPathPrefix.lastIndexOf('/'));
+        FileObject parent = utils.resolve(parentPath);
+        boolean exists = parent.exists();
+        logger.info("Resolving parent path: {}, exists? {}", parentPath, exists);
+        assertFalse("Parent folder should not exist", exists);
+
+        utils.newSftpFile(utils.getSftpFileUri(defaultPathPrefix));
+
+        parent = utils.resolve(parentPath);
+        exists = parent.exists();
+        logger.info("Resolving (again) parent path: {}, exists? {}", parentPath, exists);
+        assertTrue("Parent folder must be created", parent.exists());
+    }
+
+    @Test
+    public void testSftpFileOutputNextFile()
+    {
+        SftpFileOutputPlugin.PluginTask task = defaultTask();
+
+        SftpLocalFileOutput localFileOutput = new SftpLocalFileOutput(task, 1);
+        localFileOutput.nextFile();
+        assertNotNull("Must use local temp file", localFileOutput.getLocalOutput());
+        assertNull("Must not use remote temp file", localFileOutput.getRemoteOutput());
+        localFileOutput.close();
+
+        SftpRemoteFileOutput remoteFileOutput = new SftpRemoteFileOutput(task, 1);
+        remoteFileOutput.nextFile();
+        assertNull("Must not use local temp file", remoteFileOutput.getLocalOutput());
+        assertNotNull("Must use remote temp file", remoteFileOutput.getRemoteOutput());
+        remoteFileOutput.close();
+    }
+
+    private String defaultConfig(final String pathPrefix)
+    {
+        return "type: sftp\n" +
+                "host: " + HOST + "\n" +
+                "port: " + PORT + "\n" +
+                "user: " + USERNAME + "\n" +
+                "password: " + PASSWORD + "\n" +
+                "path_prefix: " + pathPrefix + "\n" +
+                "file_ext: txt\n" +
+                "formatter:\n" +
+                "  type: csv\n" +
+                "  newline: CRLF\n" +
+                "  newline_in_field: LF\n" +
+                "  header_line: true\n" +
+                "  charset: UTF-8\n" +
+                "  quote_policy: NONE\n" +
+                "  quote: \"\\\"\"\n" +
+                "  escape: \"\\\\\"\n" +
+                "  null_string: \"\"\n" +
+                "  default_timezone: 'UTC'";
+    }
+
+    private PluginTask defaultTask()
+    {
+        ConfigSource config = getConfigFromYaml(defaultConfig(defaultPathPrefix));
+        return config.loadConfig(SftpFileOutputPlugin.PluginTask.class);
+    }
+
+    private byte[] randBytes(final int len)
+    {
+        byte[] bytes = new byte[len];
+        new Random().nextBytes(bytes);
+        return bytes;
+    }
+
+    private File writeBytesToInputFile(final byte[] expected) throws IOException
+    {
+        File input = File.createTempFile("anything", ".dat");
+        OutputStream out = new BufferedOutputStream(new FileOutputStream(input));
+        out.write(expected);
+        out.close();
+        return input;
+    }
+
+    private void assertEmptyUploadedFile(final String pathPrefix)
+    {
+        List<String> fileList = lsR(Lists.<String>newArrayList(), Paths.get(testFolder.getRoot().getAbsolutePath()));
+        assertThat(fileList, hasItem(containsString(pathPrefix)));
+
+        String filePath = testFolder.getRoot().getAbsolutePath() + File.separator + pathPrefix;
+        File output = new File(filePath);
+        assertEquals(0, output.length());
     }
 }

--- a/src/test/java/org/embulk/output/sftp/TestSftpLocalFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sftp/TestSftpLocalFileOutputPlugin.java
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertThat;
 import static org.msgpack.value.ValueFactory.newMap;
 import static org.msgpack.value.ValueFactory.newString;
 
-public class TestSftpFileOutputPlugin
+public class TestSftpLocalFileOutputPlugin
 {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
@@ -74,7 +74,7 @@ public class TestSftpFileOutputPlugin
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
-    private Logger logger = runtime.getExec().getLogger(TestSftpFileOutputPlugin.class);
+    private Logger logger = runtime.getExec().getLogger(TestSftpLocalFileOutputPlugin.class);
     private FileOutputRunner runner;
     private SshServer sshServer;
     private static final String HOST = "127.0.0.1";

--- a/src/test/java/org/embulk/output/sftp/utils/TestTimedCallable.java
+++ b/src/test/java/org/embulk/output/sftp/utils/TestTimedCallable.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -15,24 +14,6 @@ public class TestTimedCallable
 {
     @Rule
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
-
-    @Test
-    public void testCallNonInterruptible()
-    {
-        try {
-            new TimedCallable<Void>()
-            {
-                @Override
-                public Void call() throws Exception
-                {
-                    throw new Exception("Fake error");
-                }
-            }.callNonInterruptible(1, TimeUnit.SECONDS);
-        }
-        catch (Exception e) {
-            fail("Should not throw exception");
-        }
-    }
 
     @Test
     public void testCallTimeout()

--- a/src/test/java/org/embulk/output/sftp/utils/TestTimedCallable.java
+++ b/src/test/java/org/embulk/output/sftp/utils/TestTimedCallable.java
@@ -1,0 +1,55 @@
+package org.embulk.output.sftp.utils;
+
+import org.embulk.EmbulkTestRuntime;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestTimedCallable
+{
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    @Test
+    public void testCallNonInterruptible()
+    {
+        try {
+            new TimedCallable<Void>()
+            {
+                @Override
+                public Void call() throws Exception
+                {
+                    throw new Exception("Fake error");
+                }
+            }.callNonInterruptible(1, TimeUnit.SECONDS);
+        }
+        catch (Exception e) {
+            fail("Should not throw exception");
+        }
+    }
+
+    @Test
+    public void testCallTimeout()
+    {
+        try {
+            new TimedCallable<Void>()
+            {
+                @Override
+                public Void call() throws Exception
+                {
+                    Thread.sleep(200);
+                    return null;
+                }
+            }.call(100, TimeUnit.MILLISECONDS);
+        }
+        catch (Exception e) {
+            assertThat(e, instanceOf(TimeoutException.class));
+        }
+    }
+}

--- a/src/test/java/org/embulk/output/sftp/utils/TestTimeoutCloser.java
+++ b/src/test/java/org/embulk/output/sftp/utils/TestTimeoutCloser.java
@@ -1,0 +1,40 @@
+package org.embulk.output.sftp.utils;
+
+import org.embulk.EmbulkTestRuntime;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.Closeable;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertTrue;
+
+public class TestTimeoutCloser
+{
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    @Test
+    public void testTimeoutAndResume()
+    {
+        TimeoutCloser closer = new TimeoutCloser(new Closeable()
+        {
+            @Override
+            public void close()
+            {
+                try {
+                    Thread.sleep(5000);
+                }
+                catch (InterruptedException e) {
+                    fail("Failed to sleep");
+                }
+            }
+        });
+        closer.timeout = 1;
+        long start = System.currentTimeMillis();
+        closer.close();
+        long duration = System.currentTimeMillis() - start;
+        assertTrue("longer than 1s", duration > 1000);
+        assertTrue("shorter than 5s", duration < 5000);
+    }
+}

--- a/src/test/java/org/embulk/output/sftp/utils/TestTimeoutCloser.java
+++ b/src/test/java/org/embulk/output/sftp/utils/TestTimeoutCloser.java
@@ -5,9 +5,11 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.Closeable;
+import java.util.concurrent.TimeoutException;
 
 import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestTimeoutCloser
 {
@@ -15,7 +17,7 @@ public class TestTimeoutCloser
     public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     @Test
-    public void testTimeoutAndResume()
+    public void testTimeoutAndAbort()
     {
         TimeoutCloser closer = new TimeoutCloser(new Closeable()
         {
@@ -31,10 +33,13 @@ public class TestTimeoutCloser
             }
         });
         closer.timeout = 1;
-        long start = System.currentTimeMillis();
-        closer.close();
-        long duration = System.currentTimeMillis() - start;
-        assertTrue("longer than 1s", duration > 1000);
-        assertTrue("shorter than 5s", duration < 5000);
+        try {
+            closer.close();
+            fail("Should not finish");
+        }
+        catch (Exception e) {
+            assertThat(e, instanceOf(RuntimeException.class));
+            assertThat(e.getCause(), instanceOf(TimeoutException.class));
+        }
     }
 }


### PR DESCRIPTION
#### CHANGELOG
This PR introduces 2 new configs:
- `local_buffering`: whether to use local temp file as buffer. If `false` (new behavior), plugin will use remote file as buffering, ie. writing directly to remote `OutputStream`. This new behavior can help to reduce processing time, and not to use local file, which will reduce usage of disk space.
- `temp_file_threshold`: `long`, maximum file size of local temp file, before plugin will flush to server.

#### Note
To implement `local_buffering`, `SftpFileOutput` is now `SftpLocalFileOutput` and `SftpRemoteFileOutput`:
- `SftpLocalFileOutput` keeps buffering records into local temp file, and only flush to remote file when its size reaches `temp_file_threshold`.
- `SftpRemoteFileOutput` will use remote file as buffer, hence there is no threshold. The progress will show number of uploaded records, instead of file size.

I also added retry into some operations of `SftpUtils`.