### PR TITLE
Fix stalling issue when closing `remoteFile`

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpUtils.java
+++ b/src/main/java/org/embulk/output/sftp/SftpUtils.java
@@ -160,12 +160,10 @@ public class SftpUtils
                 final BufferedOutputStream outputStream = openStream(remoteFile);
                 // When channel is broken, closing resource may hang, hence the time-out wrapper
                 // Note: closing FileObject will also close OutputStream
-                try (TimeoutCloser ignored = new TimeoutCloser(outputStream)) {
+                try (final TimeoutCloser ignored1 = new TimeoutCloser(outputStream);
+                     final TimeoutCloser ignored2 = new TimeoutCloser(remoteFile)) {
                     appendFile(localTempFile, remoteFile, outputStream);
                     return null;
-                }
-                finally {
-                    remoteFile.close();
                 }
             }
         });

--- a/src/main/java/org/embulk/output/sftp/utils/TimeoutCloser.java
+++ b/src/main/java/org/embulk/output/sftp/utils/TimeoutCloser.java
@@ -10,8 +10,7 @@ import java.util.concurrent.TimeoutException;
 
 public class TimeoutCloser implements Closeable
 {
-    @VisibleForTesting
-    int timeout = 300; // 5 minutes
+    private static int timeout = 300; // 5 minutes
     private Closeable wrapped;
 
     public TimeoutCloser(Closeable wrapped)
@@ -38,5 +37,11 @@ public class TimeoutCloser implements Closeable
         catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw Throwables.propagate(e);
         }
+    }
+
+    @VisibleForTesting
+    public static void setTimeout(int timeout)
+    {
+        TimeoutCloser.timeout = timeout;
     }
 }

--- a/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
@@ -768,7 +768,7 @@ public class TestSftpFileOutputPlugin
     }
 
     @Test
-    public void testOpenStreamWithRetry() throws FileSystemException
+    public void testOpenStreamWithoutRetry() throws FileSystemException
     {
         SftpFileOutputPlugin.PluginTask task = defaultTask();
         SftpUtils utils = new SftpUtils(task);
@@ -778,9 +778,13 @@ public class TestSftpFileOutputPlugin
                 .doCallRealMethod()
                 .when(mock).getContent();
 
-        OutputStream stream = utils.openStream(mock);
-        assertNotNull(stream);
-        Mockito.verify(mock, Mockito.times(2)).getContent();
+        try {
+            utils.openStream(mock);
+            fail("Should not reach here");
+        }
+        catch (FileSystemException e) {
+            Mockito.verify(mock, Mockito.times(1)).getContent();
+        }
     }
 
     @Test

--- a/src/test/java/org/embulk/output/sftp/utils/TestTimeoutCloser.java
+++ b/src/test/java/org/embulk/output/sftp/utils/TestTimeoutCloser.java
@@ -32,7 +32,7 @@ public class TestTimeoutCloser
                 }
             }
         });
-        closer.timeout = 1;
+        TimeoutCloser.setTimeout(1);
         try {
             closer.close();
             fail("Should not finish");


### PR DESCRIPTION
#### CHANGELOG
- When connection is having problem, closing `remoteFile` will make the thread stalling, this PR will add time-out when closing `remoteFile`
- Remove retry in `openStream()` ('cause it caused nested retries)
- Add re-connect code to `uploadFile()`