### PR TITLE
Nominate developers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,34 @@ publishing {
                 }
 
                 developers {
+                    developer {
+                        name = "Civitaspo"
+                        email = "civitaspo@gmail.com"
+                    }
+                    developer {
+                        name = "Satoshi Akama"
+                        email = "satoshiakama@gmail.com"
+                    }
+                    developer {
+                        name = "Naotoshi Seo"
+                        email = "sonots@gmail.com"
+                    }
+                    developer {
+                        name = "Khoa Nguyen"
+                        email = "instcode@gmail.com"
+                    }
+                    developer {
+                        name = "Robert Nguyen"
+                        email = "ng.hung83@gmail.com"
+                    }
+                    developer {
+                        name = "John Luong"
+                        email = "jluong@treasure-data.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
                 }
 
                 scm {


### PR DESCRIPTION
We're going to release JARs of `embulk-output-sftp` to Maven Central from 0.3.0 (#63).

Maven Central needs the `<developers>` section available in `pom.xml`. In this chance, trying to nominate developers who have contributed a important portion in `embulk-output-sftp` from the Git log.